### PR TITLE
#123 Add access control sync

### DIFF
--- a/MultiplayerMod/Game/Mechanics/AccessControlEventArgs.cs
+++ b/MultiplayerMod/Game/Mechanics/AccessControlEventArgs.cs
@@ -1,0 +1,11 @@
+using System;
+using MultiplayerMod.Multiplayer.Objects;
+
+namespace MultiplayerMod.Game.Mechanics;
+
+[Serializable]
+public class AccessControlEventArgs : EventArgs {
+    public MultiplayerReference MinionProxy { get; set; }
+    public MultiplayerReference Target { get; set; }
+    public AccessControl.Permission? Permission { get; set; }
+}

--- a/MultiplayerMod/Game/Mechanics/AccessControlEvents.cs
+++ b/MultiplayerMod/Game/Mechanics/AccessControlEvents.cs
@@ -1,0 +1,57 @@
+using System;
+using HarmonyLib;
+using MultiplayerMod.Core.Patch;
+using MultiplayerMod.Multiplayer.Objects;
+
+namespace MultiplayerMod.Game.Mechanics;
+
+[HarmonyPatch(typeof(AccessControl))]
+public static class AccessControlEvents {
+
+    public static event EventHandler<AccessControlEventArgs> DefaultPermissionChanged;
+    public static event EventHandler<AccessControlEventArgs> PermissionChanged;
+
+    [HarmonyPostfix]
+    [HarmonyPatch(nameof(AccessControl.DefaultPermission), MethodType.Setter)]
+    private static void SetDefaultPermissionPostfix(AccessControl __instance, AccessControl.Permission value) =>
+        PatchControl.RunIfEnabled(
+            () => DefaultPermissionChanged?.Invoke(
+                __instance,
+                new AccessControlEventArgs {
+                    Permission = value,
+                    Target = __instance.GetMultiplayerReference()
+                }
+            )
+        );
+
+    [HarmonyPostfix]
+    [HarmonyPatch(nameof(AccessControl.SetPermission))]
+    private static void SetPermissionPostfix(
+        AccessControl __instance,
+        MinionAssignablesProxy key,
+        AccessControl.Permission permission
+    ) => PatchControl.RunIfEnabled(
+        () => PermissionChanged?.Invoke(
+            __instance,
+            new AccessControlEventArgs {
+                Permission = permission,
+                Target = __instance.GetMultiplayerReference(),
+                MinionProxy = key.GetMultiplayerReference()
+            }
+        )
+    );
+
+    [HarmonyPostfix]
+    [HarmonyPatch(nameof(AccessControl.ClearPermission))]
+    private static void ClearPermissionPostifx(AccessControl __instance, MinionAssignablesProxy key) =>
+        PatchControl.RunIfEnabled(
+            () => PermissionChanged?.Invoke(
+                __instance,
+                new AccessControlEventArgs {
+                    Target = __instance.GetMultiplayerReference(),
+                    MinionProxy = key.GetMultiplayerReference()
+                }
+            )
+        );
+
+}

--- a/MultiplayerMod/Multiplayer/Commands/Mechanics/Access/AbstractAccessControlCommand.cs
+++ b/MultiplayerMod/Multiplayer/Commands/Mechanics/Access/AbstractAccessControlCommand.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using MultiplayerMod.Game.Mechanics;
+
+namespace MultiplayerMod.Multiplayer.Commands.Mechanics.Access;
+
+[Serializable]
+public abstract class AbstractAccessControlCommand : IMultiplayerCommand {
+
+    protected AccessControlEventArgs Arguments;
+
+    protected AbstractAccessControlCommand(AccessControlEventArgs arguments) {
+        Arguments = arguments;
+    }
+
+    public void Execute() {
+        var control = Arguments.Target.GetComponent<AccessControl>();
+        Apply(control);
+        RefreshSideScreen(control);
+    }
+
+    protected virtual void Apply(AccessControl control) { }
+
+    private void RefreshSideScreen(AccessControl control) {
+        if (DetailsScreen.Instance.currentSideScreen is not AccessControlSideScreen screen)
+            return;
+
+        if (screen.target == control)
+            screen.Refresh(screen.identityList, false);
+    }
+
+}

--- a/MultiplayerMod/Multiplayer/Commands/Mechanics/Access/ChangeDefaultPermission.cs
+++ b/MultiplayerMod/Multiplayer/Commands/Mechanics/Access/ChangeDefaultPermission.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using MultiplayerMod.Game.Mechanics;
+
+namespace MultiplayerMod.Multiplayer.Commands.Mechanics.Access;
+
+[Serializable]
+public class ChangeDefaultPermission : AbstractAccessControlCommand {
+
+    public ChangeDefaultPermission(AccessControlEventArgs arguments) : base(arguments) { }
+
+    protected override void Apply(AccessControl control) {
+        // ReSharper disable once PossibleInvalidOperationException
+        control.DefaultPermission = Arguments.Permission.Value;
+    }
+
+}

--- a/MultiplayerMod/Multiplayer/Commands/Mechanics/Access/ChangePermission.cs
+++ b/MultiplayerMod/Multiplayer/Commands/Mechanics/Access/ChangePermission.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using MultiplayerMod.Game.Mechanics;
+
+namespace MultiplayerMod.Multiplayer.Commands.Mechanics.Access;
+
+[Serializable]
+public class ChangePermission : AbstractAccessControlCommand {
+
+    public ChangePermission(AccessControlEventArgs arguments) : base(arguments) { }
+
+    protected override void Apply(AccessControl control) {
+        var proxy = Arguments.MinionProxy.GetComponent<MinionAssignablesProxy>();
+        if (Arguments.Permission != null)
+            control.SetPermission(proxy, Arguments.Permission.Value);
+        else
+            control.ClearPermission(proxy);
+    }
+
+}

--- a/MultiplayerMod/Multiplayer/Configuration/GameEventBindings.cs
+++ b/MultiplayerMod/Multiplayer/Configuration/GameEventBindings.cs
@@ -1,8 +1,10 @@
 ﻿using MultiplayerMod.Core.Dependency;
 using MultiplayerMod.Core.Logging;
+using MultiplayerMod.Game.Mechanics;
 using MultiplayerMod.Game.UI;
 using MultiplayerMod.Game.UI.Screens.Events;
 using MultiplayerMod.Game.UI.Tools.Events;
+using MultiplayerMod.Multiplayer.Commands.Mechanics.Access;
 using MultiplayerMod.Multiplayer.Commands.Overlay;
 using MultiplayerMod.Multiplayer.Commands.Screens.Consumable;
 using MultiplayerMod.Multiplayer.Commands.Screens.Immigration;
@@ -40,6 +42,7 @@ public class GameEventBindings {
         BindScreens();
         BindTools();
         BindOverlays();
+        BindMechanics();
 
         bound = true;
     }
@@ -122,6 +125,11 @@ public class GameEventBindings {
     private void BindOverlays() {
         DiseaseOverlayEvents.DiseaseSettingsChanged += (minGerm, enableAutoDisinfect) =>
             client.Send(new SetDisinfectSettings(minGerm, enableAutoDisinfect));
+    }
+
+    private void BindMechanics() {
+        AccessControlEvents.DefaultPermissionChanged += (_, args) => client.Send(new ChangeDefaultPermission(args));
+        AccessControlEvents.PermissionChanged += (_, args) => client.Send(new ChangePermission(args));
     }
 
 }

--- a/MultiplayerMod/Multiplayer/Objects/GameObjectExtensions.cs
+++ b/MultiplayerMod/Multiplayer/Objects/GameObjectExtensions.cs
@@ -1,0 +1,16 @@
+using System.Runtime.CompilerServices;
+using UnityEngine;
+
+namespace MultiplayerMod.Multiplayer.Objects;
+
+public static class GameObjectExtensions {
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static MultiplayerReference GetMultiplayerReference(this GameObject gameObject) =>
+        new(gameObject.GetComponent<MultiplayerInstance>().Id);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static MultiplayerReference GetMultiplayerReference(this KMonoBehaviour component) =>
+        GetMultiplayerReference(component.gameObject);
+
+}

--- a/MultiplayerMod/Multiplayer/Objects/MultiplayerId.cs
+++ b/MultiplayerMod/Multiplayer/Objects/MultiplayerId.cs
@@ -3,4 +3,4 @@
 namespace MultiplayerMod.Multiplayer.Objects;
 
 [Serializable]
-public record MultiplayerId(IPlayer player, long objectId);
+public record MultiplayerId(IPlayer Player, long ObjectId);

--- a/MultiplayerMod/Multiplayer/Objects/MultiplayerReference.cs
+++ b/MultiplayerMod/Multiplayer/Objects/MultiplayerReference.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using MultiplayerMod.Multiplayer.State;
+using UnityEngine;
+
+namespace MultiplayerMod.Multiplayer.Objects;
+
+[Serializable]
+public class MultiplayerReference {
+
+    private MultiplayerId id;
+
+    public MultiplayerReference(MultiplayerId id) {
+        this.id = id;
+    }
+
+    public GameObject GetGameObject() => MultiplayerGame.Objects[id];
+
+    public T GetComponent<T>() => MultiplayerGame.Objects[id].GetComponent<T>();
+
+}


### PR DESCRIPTION
This provides access synchronization for anything that has `AccessControl`, e.g. doors.
**Bonus**: "Copy Settings" tool works fine with these changes, even the access screen is refreshed.