### PR TITLE
#92 Add general event and command for side screens.

### DIFF
--- a/MultiplayerMod/Game/MainMenuExtensions.cs
+++ b/MultiplayerMod/Game/MainMenuExtensions.cs
@@ -4,14 +4,14 @@ public static class MainMenuExtensions {
 
     private const int defaultButtonFontSize = 22;
 
-    public static KButton AddButton(this MainMenu menu, string text, bool highlight, System.Action action) {
+    public static void AddButton(this MainMenu menu, string text, bool highlight, System.Action action) {
         var buttonInfo = new MainMenu.ButtonInfo(
             new LocString(text),
             action,
             defaultButtonFontSize,
             highlight ? menu.topButtonStyle : menu.normalButtonStyle
         );
-        return menu.MakeButton(buttonInfo);
+        menu.MakeButton(buttonInfo);
     }
 
 }

--- a/MultiplayerMod/Game/UI/Screens/Events/SideScreenEvents.cs
+++ b/MultiplayerMod/Game/UI/Screens/Events/SideScreenEvents.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using MultiplayerMod.Core.Patch;
+using UnityEngine;
+
+namespace MultiplayerMod.Game.UI.Screens.Events;
+
+public static class SideScreenEvents {
+
+    public static event Action<SideScreenContent, GameObject, FieldInfo> OnAction;
+
+    // TODO check every type for all its content being synced and remove from here.
+    private static readonly Type[] excludeTypes = {
+        typeof(TagFilterScreen), typeof(AccessControlSideScreen), typeof(ActiveRangeSideScreen),
+        typeof(AlarmSideScreen), typeof(ArtableSelectionSideScreen), typeof(ArtifactAnalysisSideScreen),
+        typeof(AssignableSideScreen), typeof(AutoPlumberSideScreen), typeof(AutomatableSideScreen),
+        typeof(ButtonMenuSideScreen), typeof(CapacityControlSideScreen), typeof(CheckboxListGroupSideScreen),
+        typeof(ClusterDestinationSideScreen), typeof(ClusterGridWorldSideScreen),
+        typeof(ClusterLocationFilterSideScreen), typeof(CometDetectorSideScreen), typeof(CommandModuleSideScreen),
+        typeof(ComplexFabricatorSideScreen), typeof(ConditionListSideScreen), typeof(ConfigureConsumerSideScreen),
+        typeof(CounterSideScreen), typeof(CritterSensorSideScreen), typeof(DispenserSideScreen),
+        typeof(DoorToggleSideScreen), typeof(DualSliderSideScreen), typeof(FilterSideScreen),
+        typeof(FlatTagFilterSideScreen), typeof(GeneShufflerSideScreen), typeof(GeneticAnalysisStationSideScreen),
+        typeof(GeoTunerSideScreen), typeof(HabitatModuleSideScreen), typeof(HarvestModuleSideScreen),
+        typeof(HighEnergyParticleDirectionSideScreen), typeof(IncubatorSideScreen), typeof(IntSliderSideScreen),
+        typeof(LaunchButtonSideScreen), typeof(LaunchPadSideScreen), typeof(LimitValveSideScreen),
+        typeof(LogicBitSelectorSideScreen), typeof(LogicBroadcastChannelSideScreen), typeof(LureSideScreen),
+        typeof(MinionTodoSideScreen), typeof(ModuleFlightUtilitySideScreen), typeof(MonumentSideScreen),
+        typeof(NToggleSideScreen), typeof(PixelPackSideScreen), typeof(PlanterSideScreen),
+        typeof(PlayerControlledToggleSideScreen), typeof(ProgressBarSideScreen), typeof(RailGunSideScreen),
+        typeof(ReceptacleSideScreen), typeof(RequestCrewSideScreen), typeof(ResearchSideScreen),
+        typeof(RocketModuleSideScreen), typeof(RocketRestrictionSideScreen), typeof(RoleStationSideScreen),
+        typeof(SealedDoorSideScreen), typeof(SelfDestructButtonSideScreen), typeof(SingleCheckboxSideScreen),
+        typeof(SingleSliderSideScreen), typeof(SuitLockerSideScreen), typeof(TelepadSideScreen),
+        typeof(TelescopeSideScreen), typeof(TemperatureSwitchSideScreen), typeof(TemporalTearSideScreen),
+        typeof(ThresholdSwitchSideScreen), typeof(TimeRangeSideScreen), typeof(TimerSideScreen),
+        typeof(TreeFilterableSideScreen), typeof(ValveSideScreen), typeof(WarpPortalSideScreen),
+    };
+
+    [HarmonyPatch]
+    // ReSharper disable once UnusedType.Local
+    private static class SideScreenContentEvents {
+
+        private static IEnumerable<MethodBase> TargetMethods() {
+            return Assembly.GetAssembly(typeof(SideScreenContent))
+                .GetTypes()
+                .Where(type => type.IsClass && !type.IsAbstract && type.IsSubclassOf(typeof(SideScreenContent)))
+                .Where(type => !excludeTypes.Contains(type))
+                .Distinct()
+                .Select(type => type.GetMethod("SetTarget"))
+                .ToList();
+        }
+
+        [HarmonyPostfix]
+        // ReSharper disable once UnusedMember.Local
+        private static void SetTarget(SideScreenContent __instance, GameObject __0) {
+            var sideScreenContent = __instance;
+            var target = __0;
+            var fieldInfos = sideScreenContent.GetType()
+                .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            foreach (var fieldInfo in fieldInfos) {
+                var fieldType = fieldInfo.GetType();
+                var fieldValue = fieldInfo.GetValue(sideScreenContent);
+
+                void InvokeEventIfNeeded() =>
+                    PatchControl.RunIfEnabled(() => OnAction?.Invoke(sideScreenContent, target, fieldInfo));
+
+                switch (fieldValue) {
+                    case KToggle toggle:
+                        toggle!.onClick += InvokeEventIfNeeded;
+                        break;
+                    case KButton button:
+                        button.onClick += InvokeEventIfNeeded;
+                        break;
+                    case KSlider slider:
+                        slider.onDrag += InvokeEventIfNeeded;
+                        break;
+                    case KInputField input:
+                        input.onEndEdit += InvokeEventIfNeeded;
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/MultiplayerMod/Multiplayer/Commands/Screens/UserMenu/ClickUserMenuButton.cs
+++ b/MultiplayerMod/Multiplayer/Commands/Screens/UserMenu/ClickUserMenuButton.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Linq;
 using System.Reflection;
 using MultiplayerMod.Core.Logging;
 using MultiplayerMod.Multiplayer.Objects;
 using MultiplayerMod.Multiplayer.State;
 using UnityEngine;
-using Object = UnityEngine.Object;
 
 namespace MultiplayerMod.Multiplayer.Commands.Screens.UserMenu;
 

--- a/MultiplayerMod/Multiplayer/Commands/Screens/UserMenu/InteractWithSideScreen.cs
+++ b/MultiplayerMod/Multiplayer/Commands/Screens/UserMenu/InteractWithSideScreen.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using MultiplayerMod.Multiplayer.Objects;
+using UnityEngine;
+
+namespace MultiplayerMod.Multiplayer.Commands.Screens.UserMenu;
+
+[Serializable]
+public class InteractWithSideScreen : IMultiplayerCommand {
+
+    private readonly Type sideScreenType;
+    private readonly string fieldName;
+    private readonly MultiplayerReference multiplayerReference;
+
+    public InteractWithSideScreen(SideScreenContent sideScreen, GameObject target, FieldInfo field) {
+        sideScreenType = sideScreen.GetType();
+        fieldName = field.Name;
+        multiplayerReference = target.GetMultiplayerReference();
+    }
+
+    public void Execute() {
+        // Necessary for Click and other input methods go through.
+        var initialHasFocus = KInputManager.hasFocus;
+        KInputManager.hasFocus = true;
+        var field = sideScreenType.GetField(
+            fieldName,
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        var value = field!.GetValue(SideScreenContent);
+        switch (value) {
+            case KToggle toggle:
+                toggle.Click();
+                break;
+            case KButton button:
+                button.SignalClick(KKeyCode.Mouse2);
+                break;
+
+            // TODO handle other cases.
+        }
+        KInputManager.hasFocus = initialHasFocus;
+    }
+
+    private SideScreenContent SideScreenContent {
+        get {
+            var sideScreen =
+                DetailsScreen.Instance.sideScreens.Single(screen => screen.screenPrefab.GetType() == sideScreenType);
+            var instance = Util.KInstantiateUI<SideScreenContent>(sideScreen.screenPrefab.gameObject);
+            var target = multiplayerReference.GetGameObject();
+            if (target != null) {
+                instance.SetTarget(target);
+            }
+            callMethod(instance, "OnPrefabInit");
+            callMethod(instance, "OnSpawn");
+            return instance;
+        }
+    }
+
+    private void callMethod(SideScreenContent sideScreenContent, string methodName) {
+        var methodInfo = sideScreenType.GetMethod(
+            methodName,
+            BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly,
+            null,
+            new Type[] { },
+            new ParameterModifier[] { }
+        );
+        methodInfo?.Invoke(sideScreenContent, new object[] { });
+    }
+}

--- a/MultiplayerMod/Multiplayer/Configuration/GameEventBindings.cs
+++ b/MultiplayerMod/Multiplayer/Configuration/GameEventBindings.cs
@@ -92,6 +92,9 @@ public class GameEventBindings {
             containers => client.Send(new InitializeImmigration(containers));
         ImmigrantScreenEvents.Proceed += deliverable => client.Send(new ProceedImmigration(deliverable));
         ImmigrantScreenEvents.Reject += () => client.Send(new RejectImmigration());
+
+        SideScreenEvents.OnAction += (sideScreen, target, field) =>
+            client.Send(new InteractWithSideScreen(sideScreen, target, field));
     }
 
     private void BindTools() {


### PR DESCRIPTION
Currently it filters out all side screen since they were not tested. Idea is to go through each of them and make sure that the event and command covers all required action syncs. It is possible that some sidescreens couldn't be easily synced through general event. However the idea is to cover 80%+ of sidescreens with general to avoid creating 70+ different events and commands.