### PR TITLE
#146 Add command exception handler

### DIFF
--- a/MultiplayerMod/Multiplayer/Configuration/CommandExceptionHandler.cs
+++ b/MultiplayerMod/Multiplayer/Configuration/CommandExceptionHandler.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using MultiplayerMod.Core.Logging;
+using MultiplayerMod.Multiplayer.Objects;
+
+namespace MultiplayerMod.Multiplayer.Configuration;
+
+public class CommandExceptionHandler {
+
+    private static readonly Core.Logging.Logger log = LoggerFactory.GetLogger<CommandExceptionHandler>();
+
+    public void Handle(IMultiplayerCommand command, Exception exception) {
+        switch (exception) {
+            case MultiplayerObjectNotFoundException e:
+                log.Warning($"Multiplayer object {e.Id} not found in command {command.GetType().FullName}");
+                return;
+            default:
+                throw exception;
+        }
+    }
+
+}

--- a/MultiplayerMod/Multiplayer/Objects/MultiplayerObjectNotFoundException.cs
+++ b/MultiplayerMod/Multiplayer/Objects/MultiplayerObjectNotFoundException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace MultiplayerMod.Multiplayer.Objects;
+
+public class MultiplayerObjectNotFoundException : Exception {
+
+    public MultiplayerId Id { get; }
+
+    public MultiplayerObjectNotFoundException(MultiplayerId id) {
+        Id = id;
+    }
+
+}

--- a/MultiplayerMod/Multiplayer/Objects/MultiplayerObjects.cs
+++ b/MultiplayerMod/Multiplayer/Objects/MultiplayerObjects.cs
@@ -23,8 +23,7 @@ public class MultiplayerObjects {
 
     public GameObject this[MultiplayerId id] {
         get {
-            if (!objects.TryGetValue(id, out var result))
-                log.Warning($"Object {id} not found");
+            objects.TryGetValue(id, out var result);
             return result;
         }
     }

--- a/MultiplayerMod/Multiplayer/Objects/MultiplayerReference.cs
+++ b/MultiplayerMod/Multiplayer/Objects/MultiplayerReference.cs
@@ -7,13 +7,16 @@ namespace MultiplayerMod.Multiplayer.Objects;
 [Serializable]
 public class MultiplayerReference {
 
-    private MultiplayerId id;
+    public MultiplayerId Id { get; }
 
     public MultiplayerReference(MultiplayerId id) {
-        this.id = id;
+        Id = id;
     }
 
-    public GameObject GetGameObject() => MultiplayerGame.Objects[id];
+    public GameObject GetGameObject() {
+        var gameObject = MultiplayerGame.Objects[Id] ?? throw new MultiplayerObjectNotFoundException(Id);
+        return gameObject;
+    }
 
     public T GetComponent<T>() where T : class => GetGameObject()?.GetComponent<T>();
 

--- a/MultiplayerMod/Multiplayer/Objects/MultiplayerReference.cs
+++ b/MultiplayerMod/Multiplayer/Objects/MultiplayerReference.cs
@@ -18,6 +18,6 @@ public class MultiplayerReference {
         return gameObject;
     }
 
-    public T GetComponent<T>() where T : class => GetGameObject()?.GetComponent<T>();
+    public T GetComponent<T>() where T : class => GetGameObject().GetComponent<T>();
 
 }


### PR DESCRIPTION
Now we can safely use `MultiplayerReference.GetGameObject` or `MultiplayerReference.GetComponent<T>`.