### PR TITLE
#145 Fix NPE in ChangeSchedulesList.cs and ClickUserMenuButton.cs for newly created objects.

### DIFF
--- a/MultiplayerMod/Multiplayer/Commands/Screens/Schedule/ChangeSchedulesList.cs
+++ b/MultiplayerMod/Multiplayer/Commands/Screens/Schedule/ChangeSchedulesList.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using MultiplayerMod.Multiplayer.Objects;
-using MultiplayerMod.Multiplayer.State;
 
 namespace MultiplayerMod.Multiplayer.Commands.Screens.Schedule;
 
@@ -32,7 +31,7 @@ public class ChangeSchedulesList : IMultiplayerCommand {
     private class SerializableSchedule {
         public string name;
         public bool alarmActivated;
-        private List<MultiplayerId> assigned;
+        private List<MultiplayerReference> assigned;
         private List<string> blocks;
 
         private static Dictionary<String, ScheduleGroup> groups =
@@ -55,16 +54,13 @@ public class ChangeSchedulesList : IMultiplayerCommand {
             name = schedule.name;
             alarmActivated = schedule.alarmActivated;
             blocks = schedule.blocks.Select(block => block.GroupId).ToList();
-            assigned = schedule.assigned.Select(@ref => @ref.obj.GetComponent<MultiplayerInstance>().Id).ToList();
+            assigned = schedule.assigned.Select(@ref => @ref.obj.GetMultiplayerReference()).ToList();
         }
 
         public List<ScheduleGroup> Groups => blocks.Select(block => groups[block]).ToList();
-        public List<Ref<Schedulable>> Assigned => assigned.Select(id => new Ref<Schedulable>(Get(id))).ToList();
 
-        public Schedulable Get(MultiplayerId id) {
-            var instance = MultiplayerGame.Objects[id];
-            return instance == null ? null : instance.GetComponent<Schedulable>();
-        }
+        public List<Ref<Schedulable>> Assigned =>
+            assigned.Select(reference => new Ref<Schedulable>(reference.GetComponent<Schedulable>())).ToList();
     }
 
 }

--- a/MultiplayerMod/Multiplayer/Commands/Screens/UserMenu/ClickUserMenuButton.cs
+++ b/MultiplayerMod/Multiplayer/Commands/Screens/UserMenu/ClickUserMenuButton.cs
@@ -2,7 +2,6 @@
 using System.Reflection;
 using MultiplayerMod.Core.Logging;
 using MultiplayerMod.Multiplayer.Objects;
-using MultiplayerMod.Multiplayer.State;
 using UnityEngine;
 
 namespace MultiplayerMod.Multiplayer.Commands.Screens.UserMenu;
@@ -12,23 +11,17 @@ public class ClickUserMenuButton : IMultiplayerCommand {
 
     private static readonly Core.Logging.Logger log = LoggerFactory.GetLogger(typeof(ClickUserMenuButton));
 
-    private MultiplayerId multiplayerId;
+    private MultiplayerReference reference;
     private Type actionDeclaringType;
     private string actionName;
 
     public ClickUserMenuButton(GameObject gameObject, System.Action action) {
-        multiplayerId = gameObject.GetComponent<MultiplayerInstance>().Id;
+        reference = gameObject.GetMultiplayerReference();
         actionDeclaringType = action.Method.DeclaringType;
         actionName = action.Method.Name;
     }
 
     public void Execute() {
-        var gameObject = MultiplayerGame.Objects[multiplayerId];
-        if (gameObject == null) return;
-
-        var actionObject = gameObject.GetComponent(actionDeclaringType);
-        if (actionObject == null) return;
-
         try {
             var methodInfo = actionDeclaringType.GetMethod(
                 actionName,
@@ -37,7 +30,7 @@ public class ClickUserMenuButton : IMultiplayerCommand {
                 new Type[] { },
                 new ParameterModifier[] { }
             );
-            methodInfo?.Invoke(actionObject, new object[] { });
+            methodInfo?.Invoke(reference.GetComponent(actionDeclaringType), new object[] { });
         } catch (Exception e) {
             log.Error(e.ToString);
         }

--- a/MultiplayerMod/Multiplayer/Objects/MultiplayerReference.cs
+++ b/MultiplayerMod/Multiplayer/Objects/MultiplayerReference.cs
@@ -20,4 +20,6 @@ public class MultiplayerReference {
 
     public T GetComponent<T>() where T : class => GetGameObject().GetComponent<T>();
 
+    public Component GetComponent(Type type) => GetGameObject().GetComponent(type);
+
 }


### PR DESCRIPTION
Previous checks were vague and allowing further command execution in case of not found object. Switch to MultiplayerReference to get an exception (handled) in case of not synced objects.