### PR TITLE
Fix a lot of warnings due to generic method being patched.

### DIFF
--- a/MultiplayerMod/Game/Mechanics/Objects/ObjectEvents.cs
+++ b/MultiplayerMod/Game/Mechanics/Objects/ObjectEvents.cs
@@ -94,7 +94,7 @@ public static class ObjectEvents {
             new[] { nameof(FlatTagFilterable.ToggleTag) }
         }, {
             typeof(GeneShuffler),
-            new[] { nameof(GeneShuffler.SetWorkTime), nameof(GeneShuffler.RequestRecharge) }
+            new[] { nameof(GeneShuffler.RequestRecharge) }
         }, {
             typeof(GeneticAnalysisStation.StatesInstance),
             new[] { nameof(GeneticAnalysisStation.StatesInstance.SetSeedForbidden) }


### PR DESCRIPTION
This was causing host crash after few minutes of MP game as well.