### PR TITLE
Stackable patch context

### DIFF
--- a/MultiplayerMod/Core/Patch/Context/PatchContext.cs
+++ b/MultiplayerMod/Core/Patch/Context/PatchContext.cs
@@ -1,0 +1,36 @@
+﻿using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace MultiplayerMod.Core.Patch.Context;
+
+public class PatchContext {
+
+    private static readonly PatchContext rootContext = new(true);
+
+    private static readonly ThreadLocal<PatchContextGuard> holder = new(() => new PatchContextGuard(rootContext));
+
+    public static PatchContext Current => holder.Value.Peek();
+    public static PatchContext Global { get; set; } = new(true);
+
+    public bool PatchesEnabled { get; private set; }
+
+    public PatchContext(bool patchesEnabled) {
+        PatchesEnabled = patchesEnabled;
+    }
+
+    public static void Use(PatchContext context, System.Action action) {
+        Enter(context);
+        try {
+            action();
+        } finally {
+            Leave();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Enter(PatchContext context) => holder.Value.Push(context);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Leave() => holder.Value.Pop();
+
+}

--- a/MultiplayerMod/Core/Patch/Context/PatchContextFailedIntegrityException.cs
+++ b/MultiplayerMod/Core/Patch/Context/PatchContextFailedIntegrityException.cs
@@ -1,0 +1,7 @@
+﻿using System;
+
+namespace MultiplayerMod.Core.Patch.Context;
+
+public class PatchContextIntegrityFailureException : Exception {
+    public PatchContextIntegrityFailureException(string message) : base(message) { }
+}

--- a/MultiplayerMod/Core/Patch/Context/PatchContextGuard.cs
+++ b/MultiplayerMod/Core/Patch/Context/PatchContextGuard.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+
+namespace MultiplayerMod.Core.Patch.Context;
+
+public class PatchContextGuard {
+
+    private int lastPushUpdateCycle;
+    private readonly Stack<TrackedPatchContext> stack = new();
+
+    public PatchContextGuard(PatchContext rootContext) {
+        stack.Push(new TrackedPatchContext(rootContext, new StackTrace(true)));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public PatchContext Peek() => stack.Peek().TargetContext;
+
+    public void Push(PatchContext context) {
+        if (lastPushUpdateCycle < Time.frameCount) {
+            if (stack.Count != 1) {
+                var lastIndex = stack.Count - 1;
+                var contextStack = string.Join(
+                    "\n",
+                    stack.Select((it, i) => $"Context #{lastIndex - i} set {it.Origin.ToString().TrimStart()}")
+                );
+                throw new PatchContextIntegrityFailureException(
+                    $"Patch context stack contains context from a previous cycle.\n" +
+                    $"============== Context stack ==============\n" +
+                    $"{contextStack}\n" +
+                    $"==========================================="
+                );
+            }
+        }
+        stack.Push(new TrackedPatchContext(context, new StackTrace(1)));
+        lastPushUpdateCycle = Time.frameCount;
+    }
+
+    public void Pop() {
+        stack.Pop();
+        if (stack.Count == 0)
+            throw new PatchContextIntegrityFailureException("Root patch context was evacuated");
+    }
+
+    private record TrackedPatchContext(PatchContext TargetContext, StackTrace Origin);
+
+}

--- a/MultiplayerMod/Core/Patch/PatchControl.cs
+++ b/MultiplayerMod/Core/Patch/PatchControl.cs
@@ -1,27 +1,16 @@
-﻿using System.Threading;
+﻿using MultiplayerMod.Core.Patch.Context;
 
 namespace MultiplayerMod.Core.Patch;
 
 public static class PatchControl {
 
-    private static readonly ThreadLocal<bool> disabled = new(() => false);
+    public static readonly PatchContext DisablePatches = new(patchesEnabled: false);
+    public static readonly PatchContext EnablePatches = new(patchesEnabled: true);
 
-    public static bool Disabled {
-        private get => disabled.Value;
-        set => disabled.Value = value;
-    }
-
-    public static void RunWithDisabledPatches(System.Action action) {
-        Disabled = true;
-        try {
-            action();
-        } finally {
-            Disabled = false;
-        }
-    }
+    public static void RunWithDisabledPatches(System.Action action) => PatchContext.Use(DisablePatches, action);
 
     public static void RunIfEnabled(System.Action action) {
-        if (!Disabled)
+        if (PatchContext.Global.PatchesEnabled && PatchContext.Current.PatchesEnabled)
             action();
     }
 

--- a/MultiplayerMod/Game/Mechanics/Minions/MinionDeliveryState.cs
+++ b/MultiplayerMod/Game/Mechanics/Minions/MinionDeliveryState.cs
@@ -1,18 +1,21 @@
 ﻿using HarmonyLib;
+using MultiplayerMod.Core.Patch;
+using MultiplayerMod.Core.Patch.Context;
 
 namespace MultiplayerMod.Game.Mechanics.Minions;
 
 [HarmonyPatch(typeof(MinionStartingStats))]
+// ReSharper disable once UnusedType.Global
 public static class MinionDeliveryState {
 
-    public static bool Spawning { get; private set; }
-
+    // ReSharper disable once UnusedMember.Local
     [HarmonyPrefix]
     [HarmonyPatch(nameof(MinionStartingStats.Deliver))]
-    private static void BeforeDelivery() => Spawning = true;
+    private static void BeforeDelivery() => PatchContext.Enter(PatchControl.DisablePatches);
 
+    // ReSharper disable once UnusedMember.Local
     [HarmonyPostfix]
     [HarmonyPatch(nameof(MinionStartingStats.Deliver))]
-    private static void AfterDelivery() => Spawning = false;
+    private static void AfterDelivery() => PatchContext.Leave();
 
 }

--- a/MultiplayerMod/Game/UI/Screens/Events/PrioritiesScreenEvents.cs
+++ b/MultiplayerMod/Game/UI/Screens/Events/PrioritiesScreenEvents.cs
@@ -19,10 +19,7 @@ public static class PrioritiesScreenEvents {
         // ReSharper disable once UnusedMember.Local
         private static void SetPersonalPriority(ChoreConsumer __instance, ChoreGroup group, int value) =>
             PatchControl.RunIfEnabled(
-                () => {
-                    if (!MinionDeliveryState.Spawning)
-                        Set?.Invoke(__instance, group, value);
-                }
+                () => { Set?.Invoke(__instance, group, value); }
             );
     }
 

--- a/MultiplayerMod/Game/UI/Screens/Events/PrioritiesScreenEvents.cs
+++ b/MultiplayerMod/Game/UI/Screens/Events/PrioritiesScreenEvents.cs
@@ -18,9 +18,7 @@ public static class PrioritiesScreenEvents {
         [HarmonyPatch(nameof(ChoreConsumer.SetPersonalPriority))]
         // ReSharper disable once UnusedMember.Local
         private static void SetPersonalPriority(ChoreConsumer __instance, ChoreGroup group, int value) =>
-            PatchControl.RunIfEnabled(
-                () => { Set?.Invoke(__instance, group, value); }
-            );
+            PatchControl.RunIfEnabled(() => Set?.Invoke(__instance, group, value));
     }
 
     [HarmonyPatch(typeof(Immigration))]

--- a/MultiplayerMod/Game/World/WorldGenSpawnerEvents.cs
+++ b/MultiplayerMod/Game/World/WorldGenSpawnerEvents.cs
@@ -1,5 +1,4 @@
 ﻿using HarmonyLib;
-using MultiplayerMod.Core.Patch;
 
 namespace MultiplayerMod.Game.World;
 
@@ -11,6 +10,6 @@ public static class WorldGenSpawnerEvents {
     [HarmonyPostfix]
     [HarmonyPatch("OnSpawn")]
     // ReSharper disable once UnusedMember.Local
-    private static void OnSpawn() => PatchControl.RunIfEnabled(() => { Spawned?.Invoke(); });
+    private static void OnSpawn() => Spawned?.Invoke();
 
 }

--- a/MultiplayerMod/Multiplayer/Configuration/GameEventBindings.cs
+++ b/MultiplayerMod/Multiplayer/Configuration/GameEventBindings.cs
@@ -1,6 +1,7 @@
 ﻿using MultiplayerMod.Core.Dependency;
 using MultiplayerMod.Core.Logging;
 using MultiplayerMod.Core.Patch;
+using MultiplayerMod.Core.Patch.Context;
 using MultiplayerMod.Game.Mechanics.Objects;
 using MultiplayerMod.Game.Mechanics.Printing;
 using MultiplayerMod.Game.UI;
@@ -95,7 +96,7 @@ public class GameEventBindings {
         PauseScreenEvents.QuitGame += () => {
             if (client.State >= MultiplayerClientState.Connecting)
                 client.Disconnect();
-            PatchControl.Disabled = true;
+            PatchContext.Global = PatchControl.DisablePatches;
         };
     }
 

--- a/MultiplayerMod/Multiplayer/Configuration/MultiplayerCoordinator.cs
+++ b/MultiplayerMod/Multiplayer/Configuration/MultiplayerCoordinator.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using MultiplayerMod.Core.Dependency;
 using MultiplayerMod.Core.Logging;
 using MultiplayerMod.Core.Patch;
+using MultiplayerMod.Core.Patch.Context;
 using MultiplayerMod.Core.Unity;
 using MultiplayerMod.Game.UI.Overlay;
 using MultiplayerMod.Game.World;
@@ -136,7 +137,7 @@ public class MultiplayerCoordinator {
         if (MultiplayerGame.Role == MultiplayerRole.None)
             return;
 
-        PatchControl.Disabled = false;
+        PatchContext.Global = PatchControl.EnablePatches;
 
         if (MultiplayerGame.Role == MultiplayerRole.Host) {
             LoadOverlay.Show();


### PR DESCRIPTION
Seems there are cases when we have to enable or disable patches hierarchically, so we have to have a stackable context for easier use.

New features:
- Stackable context.
- Global context (Enable / disable patches globally).
- Patch context stack guard (Helps to spot problems with manual `Enter` `Leave` invocations).