### PR TITLE
Command registry

### DIFF
--- a/src/MultiplayerMod.Test/Core/Dependency/DependencyContainerBuilderTests.cs
+++ b/src/MultiplayerMod.Test/Core/Dependency/DependencyContainerBuilderTests.cs
@@ -37,9 +37,9 @@ public class DependencyContainerBuilderTests {
     }
 
     [Test]
-    public void AssemblyDependenciesAreAvailable() {
+    public void AssemblyNamespaceDependenciesAreAvailable() {
         var container = new DependencyContainerBuilder()
-            .ScanAssembly(GetType().Assembly)
+            .ScanAssembly(GetType().Assembly, "MultiplayerMod.Test.Core.Dependency")
             .Build();
         Assert.DoesNotThrow(() => container.Get<DependencyA>());
         Assert.DoesNotThrow(() => container.Get<DependencyB>());

--- a/src/MultiplayerMod.Test/Multiplayer/MultiplayerTools.cs
+++ b/src/MultiplayerMod.Test/Multiplayer/MultiplayerTools.cs
@@ -5,6 +5,8 @@ using MultiplayerMod.Core.Events;
 using MultiplayerMod.Core.Scheduling;
 using MultiplayerMod.ModRuntime.Context;
 using MultiplayerMod.Multiplayer;
+using MultiplayerMod.Multiplayer.Commands;
+using MultiplayerMod.Multiplayer.Commands.Registry;
 using MultiplayerMod.Multiplayer.CoreOperations;
 using MultiplayerMod.Multiplayer.CoreOperations.Binders;
 using MultiplayerMod.Multiplayer.CoreOperations.CommandExecution;
@@ -45,8 +47,12 @@ public static class MultiplayerTools {
             .AddType<MultiplayerJoinRequestController>()
             .AddType<PlayersManagementController>()
             .AddType<SpeedControlScreenContext>()
+            .AddType<MultiplayerCommandRegistry>()
             .AddType<Recorders>()
             .AddType<TestRuntime>();
+
+        var configurer = new MultiplayerCommandsConfigurer();
+        configurer.Configure(builder);
 
         var container = builder.Build();
         var runtime = container.Get<TestRuntime>();

--- a/src/MultiplayerMod/Core/Dependency/DependencyContainerBuilder.cs
+++ b/src/MultiplayerMod/Core/Dependency/DependencyContainerBuilder.cs
@@ -11,6 +11,8 @@ public class DependencyContainerBuilder {
     private readonly List<Type> includeTypes = new();
     private readonly List<object> singletons = new();
 
+    public event Action<DependencyContainer>? ContainerCreated;
+
     public DependencyContainerBuilder ScanAssembly(Assembly assembly) {
         assemblies.Add((assembly, Array.Empty<string>()));
         return this;
@@ -54,6 +56,7 @@ public class DependencyContainerBuilder {
             container.Register(dependencyInfo);
         }
         container.PreInstantiate();
+        ContainerCreated?.Invoke(container);
         return container;
     }
 

--- a/src/MultiplayerMod/Core/Dependency/DependencyContainerBuilder.cs
+++ b/src/MultiplayerMod/Core/Dependency/DependencyContainerBuilder.cs
@@ -7,12 +7,17 @@ namespace MultiplayerMod.Core.Dependency;
 
 public class DependencyContainerBuilder {
 
-    private readonly List<Assembly> assemblies = new();
+    private readonly List<(Assembly, string[])> assemblies = new();
     private readonly List<Type> includeTypes = new();
     private readonly List<object> singletons = new();
 
     public DependencyContainerBuilder ScanAssembly(Assembly assembly) {
-        assemblies.Add(assembly);
+        assemblies.Add((assembly, Array.Empty<string>()));
+        return this;
+    }
+
+    public DependencyContainerBuilder ScanAssembly(Assembly assembly, params string[] namespaces) {
+        assemblies.Add((assembly, namespaces));
         return this;
     }
 
@@ -32,7 +37,15 @@ public class DependencyContainerBuilder {
         var container = new DependencyContainer();
         container.RegisterSingleton(container);
         singletons.ForEach(it => container.RegisterSingleton(it));
-        var types = assemblies.SelectMany(it => it.DefinedTypes)
+        var types = assemblies.SelectMany(
+                it => {
+                    var (assembly, namespaces) = it;
+                    var types = assembly.DefinedTypes;
+                    if (namespaces.Length > 0)
+                        types = types.Where(type => namespaces.Any(name => type.Namespace!.StartsWith(name)));
+                    return types;
+                }
+            )
             .Where(it => it.GetCustomAttribute<DependencyAttribute>() != null)
             .Union(includeTypes);
         foreach (var type in types) {

--- a/src/MultiplayerMod/Core/Scheduling/UnityTaskSchedulerConfigurer.cs
+++ b/src/MultiplayerMod/Core/Scheduling/UnityTaskSchedulerConfigurer.cs
@@ -9,7 +9,7 @@ namespace MultiplayerMod.Core.Scheduling;
 public class UnityTaskSchedulerConfigurer : IModComponentConfigurer {
 
     public void Configure(DependencyContainerBuilder builder) {
-        UnityObject.CreateStaticWithComponent<UnityTaskExecutor>();
+        builder.ContainerCreated += _ => UnityObject.CreateStaticWithComponent<UnityTaskExecutor>();
     }
 
 }

--- a/src/MultiplayerMod/Multiplayer/Commands/MultiplayerCommandAttribute.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/MultiplayerCommandAttribute.cs
@@ -5,4 +5,5 @@ namespace MultiplayerMod.Multiplayer.Commands;
 [AttributeUsage(AttributeTargets.Class)]
 public class MultiplayerCommandAttribute : Attribute {
     public MultiplayerCommandType Type { get; set; } = MultiplayerCommandType.Game;
+    public bool ExecuteOnServer { get; set; }
 }

--- a/src/MultiplayerMod/Multiplayer/Commands/MultiplayerCommandContext.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/MultiplayerCommandContext.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Threading;
 using MultiplayerMod.Core.Events;
 using MultiplayerMod.ModRuntime;
 using MultiplayerMod.Network;
@@ -9,25 +7,15 @@ namespace MultiplayerMod.Multiplayer.Commands;
 public class MultiplayerCommandContext {
 
     public IMultiplayerClientId? ClientId { get; }
-    public Runtime Runtime { get; }
+    public Runtime Runtime => accessor.Runtime;
+    public EventDispatcher EventDispatcher => accessor.EventDispatcher;
+    public MultiplayerGame Multiplayer => accessor.Multiplayer;
 
-    private readonly Lazy<EventDispatcher> eventDispatcher;
-    private readonly Lazy<MultiplayerGame> multiplayer;
+    private readonly MultiplayerCommandRuntimeAccessor accessor;
 
-    public EventDispatcher EventDispatcher => eventDispatcher.Value;
-    public MultiplayerGame Multiplayer => multiplayer.Value;
-
-    public MultiplayerCommandContext(IMultiplayerClientId? clientId, Runtime runtime) {
-        Runtime = runtime;
+    public MultiplayerCommandContext(IMultiplayerClientId? clientId, MultiplayerCommandRuntimeAccessor accessor) {
+        this.accessor = accessor;
         ClientId = clientId;
-        eventDispatcher = new Lazy<EventDispatcher>(
-            () => Runtime.Dependencies.Get<EventDispatcher>(),
-            LazyThreadSafetyMode.None
-        );
-        multiplayer = new Lazy<MultiplayerGame>(
-            () => Runtime.Dependencies.Get<MultiplayerGame>(),
-            LazyThreadSafetyMode.None
-        );
     }
 
 }

--- a/src/MultiplayerMod/Multiplayer/Commands/MultiplayerCommandRuntimeAccessor.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/MultiplayerCommandRuntimeAccessor.cs
@@ -1,0 +1,18 @@
+﻿using MultiplayerMod.Core.Events;
+using MultiplayerMod.ModRuntime;
+
+namespace MultiplayerMod.Multiplayer.Commands;
+
+public class MultiplayerCommandRuntimeAccessor {
+
+    public Runtime Runtime { get; }
+    public EventDispatcher EventDispatcher { get; }
+    public MultiplayerGame Multiplayer { get; }
+
+    public MultiplayerCommandRuntimeAccessor(Runtime runtime) {
+        Runtime = runtime;
+        EventDispatcher = runtime.Dependencies.Get<EventDispatcher>();
+        Multiplayer = runtime.Dependencies.Get<MultiplayerGame>();
+    }
+
+}

--- a/src/MultiplayerMod/Multiplayer/Commands/MultiplayerCommandsConfigurer.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/MultiplayerCommandsConfigurer.cs
@@ -1,0 +1,25 @@
+﻿using System.Linq;
+using JetBrains.Annotations;
+using MultiplayerMod.Core.Dependency;
+using MultiplayerMod.Core.Extensions;
+using MultiplayerMod.ModRuntime.Loader;
+using MultiplayerMod.Multiplayer.Commands.Registry;
+
+namespace MultiplayerMod.Multiplayer.Commands;
+
+[UsedImplicitly]
+public class MultiplayerCommandsConfigurer : IModComponentConfigurer {
+
+    public void Configure(DependencyContainerBuilder builder) {
+        builder.ContainerCreated += RegisterCommands;
+    }
+
+    private void RegisterCommands(DependencyContainer container) {
+        var registry = container.Get<MultiplayerCommandRegistry>();
+        GetType().Assembly.DefinedTypes
+            .Where(it => typeof(IMultiplayerCommand).IsAssignableFrom(it))
+            .Where(it => !it.IsAbstract)
+            .ForEach(it => registry.Register(it));
+    }
+
+}

--- a/src/MultiplayerMod/Multiplayer/Commands/Registry/MultiplayerCommandAlreadyRegisteredException.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Registry/MultiplayerCommandAlreadyRegisteredException.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using MultiplayerMod.Exceptions;
+
+namespace MultiplayerMod.Multiplayer.Commands.Registry;
+
+public class MultiplayerCommandAlreadyRegisteredException : MultiplayerException {
+    public MultiplayerCommandAlreadyRegisteredException(Type type) : base(
+        $"Command \"{type}\" already registered"
+    ) { }
+}

--- a/src/MultiplayerMod/Multiplayer/Commands/Registry/MultiplayerCommandConfiguration.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Registry/MultiplayerCommandConfiguration.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace MultiplayerMod.Multiplayer.Commands.Registry;
+
+public class MultiplayerCommandConfiguration {
+
+    public Type Type { get;}
+    public MultiplayerCommandType CommandType { get;}
+
+    public MultiplayerCommandConfiguration(Type type, MultiplayerCommandType commandType) {
+        Type = type;
+        CommandType = commandType;
+    }
+
+}

--- a/src/MultiplayerMod/Multiplayer/Commands/Registry/MultiplayerCommandConfiguration.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Registry/MultiplayerCommandConfiguration.cs
@@ -6,10 +6,12 @@ public class MultiplayerCommandConfiguration {
 
     public Type Type { get;}
     public MultiplayerCommandType CommandType { get;}
+    public bool ExecuteOnServer { get;}
 
-    public MultiplayerCommandConfiguration(Type type, MultiplayerCommandType commandType) {
+    public MultiplayerCommandConfiguration(Type type, MultiplayerCommandType commandType, bool executeOnServer) {
         Type = type;
         CommandType = commandType;
+        ExecuteOnServer = executeOnServer;
     }
 
 }

--- a/src/MultiplayerMod/Multiplayer/Commands/Registry/MultiplayerCommandInvalidInterfaceException.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Registry/MultiplayerCommandInvalidInterfaceException.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using MultiplayerMod.Exceptions;
+
+namespace MultiplayerMod.Multiplayer.Commands.Registry;
+
+public class MultiplayerCommandInvalidInterfaceException : MultiplayerException {
+    public MultiplayerCommandInvalidInterfaceException(Type type) : base(
+        $"Type \"{type}\" doesn't implement \"{typeof(IMultiplayerCommand)}\" interface"
+    ) { }
+}

--- a/src/MultiplayerMod/Multiplayer/Commands/Registry/MultiplayerCommandNotFoundException.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Registry/MultiplayerCommandNotFoundException.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using MultiplayerMod.Exceptions;
+
+namespace MultiplayerMod.Multiplayer.Commands.Registry;
+
+public class MultiplayerCommandNotFoundException : MultiplayerException {
+    public MultiplayerCommandNotFoundException(Type type) : base(
+        $"Command \"{type}\" not found"
+    ) { }
+}

--- a/src/MultiplayerMod/Multiplayer/Commands/Registry/MultiplayerCommandRegistry.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Registry/MultiplayerCommandRegistry.cs
@@ -37,7 +37,7 @@ public class MultiplayerCommandRegistry {
 
     private MultiplayerCommandConfiguration ExtractConfiguration(Type type) {
         var attribute = type.GetCustomAttribute<MultiplayerCommandAttribute>() ?? new MultiplayerCommandAttribute();
-        return new MultiplayerCommandConfiguration(type, attribute.Type);
+        return new MultiplayerCommandConfiguration(type, attribute.Type, attribute.ExecuteOnServer);
     }
 
 }

--- a/src/MultiplayerMod/Multiplayer/Commands/Registry/MultiplayerCommandRegistry.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Registry/MultiplayerCommandRegistry.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using JetBrains.Annotations;
+using MultiplayerMod.Core.Dependency;
+using MultiplayerMod.Core.Logging;
+
+namespace MultiplayerMod.Multiplayer.Commands.Registry;
+
+[Dependency, UsedImplicitly]
+public class MultiplayerCommandRegistry {
+
+    private readonly Core.Logging.Logger log = LoggerFactory.GetLogger<MultiplayerCommandRegistry>();
+
+    private readonly Dictionary<Type, MultiplayerCommandConfiguration> commands = new();
+
+    public void Register<T>() where T : IMultiplayerCommand => Register(typeof(T));
+
+    public void Register(Type type) {
+        if (!typeof(IMultiplayerCommand).IsAssignableFrom(type))
+            throw new MultiplayerCommandInvalidInterfaceException(type);
+
+        if (commands.ContainsKey(type))
+            throw new MultiplayerCommandAlreadyRegisteredException(type);
+
+        var configuration = ExtractConfiguration(type);
+        commands[type] = configuration;
+        log.Debug(() => $"{configuration.Type} command {type} registered");
+    }
+
+    public MultiplayerCommandConfiguration GetCommandConfiguration(Type type) {
+        if (!commands.TryGetValue(type, out var configuration))
+            throw new MultiplayerCommandNotFoundException(type);
+
+        return configuration;
+    }
+
+    private MultiplayerCommandConfiguration ExtractConfiguration(Type type) {
+        var attribute = type.GetCustomAttribute<MultiplayerCommandAttribute>() ?? new MultiplayerCommandAttribute();
+        return new MultiplayerCommandConfiguration(type, attribute.Type);
+    }
+
+}

--- a/src/MultiplayerMod/Multiplayer/Commands/Tools/AbstractBuildUtilityCommand.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Tools/AbstractBuildUtilityCommand.cs
@@ -6,11 +6,11 @@ using MultiplayerMod.Game.UI.Tools.Events;
 namespace MultiplayerMod.Multiplayer.Commands.Tools;
 
 [Serializable]
-public class AbstractBuildUtilityCommand<T> : MultiplayerCommand where T : BaseUtilityBuildTool, new() {
+public abstract class AbstractBuildUtilityCommand<T> : MultiplayerCommand where T : BaseUtilityBuildTool, new() {
 
     protected UtilityBuildEventArgs Arguments;
 
-    public AbstractBuildUtilityCommand(UtilityBuildEventArgs arguments) {
+    protected AbstractBuildUtilityCommand(UtilityBuildEventArgs arguments) {
         Arguments = arguments;
     }
 

--- a/src/MultiplayerMod/Multiplayer/Commands/Tools/AbstractDragToolCommand.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Tools/AbstractDragToolCommand.cs
@@ -8,7 +8,7 @@ using MultiplayerMod.Game.UI.Tools.Events;
 namespace MultiplayerMod.Multiplayer.Commands.Tools;
 
 [Serializable]
-public class AbstractDragToolCommand<T> : MultiplayerCommand where T : DragTool, new() {
+public abstract class AbstractDragToolCommand<T> : MultiplayerCommand where T : DragTool, new() {
 
     protected DragCompleteEventArgs Arguments;
 

--- a/src/MultiplayerMod/Multiplayer/CoreOperations/CommandExecution/MultiplayerCommandExecutor.cs
+++ b/src/MultiplayerMod/Multiplayer/CoreOperations/CommandExecution/MultiplayerCommandExecutor.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Reflection;
 using JetBrains.Annotations;
 using MultiplayerMod.Core.Dependency;
 using MultiplayerMod.Core.Logging;
 using MultiplayerMod.ModRuntime;
 using MultiplayerMod.ModRuntime.Context;
 using MultiplayerMod.Multiplayer.Commands;
+using MultiplayerMod.Multiplayer.Commands.Registry;
 using MultiplayerMod.Network;
 
 namespace MultiplayerMod.Multiplayer.CoreOperations.CommandExecution;
@@ -16,62 +15,49 @@ public class MultiplayerCommandExecutor {
 
     private readonly Core.Logging.Logger log = LoggerFactory.GetLogger<MultiplayerCommandExecutor>();
 
-    private readonly Runtime runtime;
     private readonly ExecutionLevelManager executionLevelManager;
+    private readonly MultiplayerCommandRegistry registry;
     private readonly CommandExceptionHandler exceptionHandler = new();
 
-    private readonly Dictionary<Type, Configuration> configurationCache = new();
+    private readonly MultiplayerCommandRuntimeAccessor runtimeAccessor;
 
-    public MultiplayerCommandExecutor(Runtime runtime, ExecutionLevelManager executionLevelManager) {
-        this.runtime = runtime;
+    public MultiplayerCommandExecutor(
+        Runtime runtime,
+        ExecutionLevelManager executionLevelManager,
+        MultiplayerCommandRegistry registry
+    ) {
         this.executionLevelManager = executionLevelManager;
+        this.registry = registry;
+        runtimeAccessor = new MultiplayerCommandRuntimeAccessor(runtime);
     }
 
     public void Execute(IMultiplayerClientId? clientId, IMultiplayerCommand command) {
-        var configuration = GetCommandConfiguration(command);
-        switch (configuration.Type) {
+        var configuration = registry.GetCommandConfiguration(command.GetType());
+        switch (configuration.CommandType) {
             case MultiplayerCommandType.System:
                 RunCatching(clientId, command);
                 break;
             case MultiplayerCommandType.Game:
-               executionLevelManager.RunIfLevelIsActive(
+                executionLevelManager.RunIfLevelIsActive(
                     ExecutionLevel.Game,
                     ExecutionLevel.Command,
                     () => RunCatching(clientId, command)
                 );
                 break;
             default:
-                throw new CommandConfigurationException($"{command} has invalid type \"{configuration.Type}\"");
+                throw new CommandConfigurationException(
+                    $"{command.GetType()} has unsupported type \"{configuration.Type}\""
+                );
         }
     }
 
     private void RunCatching(IMultiplayerClientId? clientId, IMultiplayerCommand command) {
         try {
             log.Trace(() => $"Executing {command}");
-            command.Execute(new MultiplayerCommandContext(clientId, runtime));
+            command.Execute(new MultiplayerCommandContext(clientId, runtimeAccessor));
         } catch (Exception exception) {
             exceptionHandler.Handle(command, exception);
         }
-    }
-
-    private Configuration GetCommandConfiguration(IMultiplayerCommand command) {
-        var type = command.GetType();
-        if (configurationCache.TryGetValue(type, out var configuration))
-            return configuration;
-
-        configuration = new Configuration(type.GetCustomAttribute<MultiplayerCommandAttribute>());
-        configurationCache[type] = configuration;
-        return configuration;
-    }
-
-    private class Configuration {
-
-        public MultiplayerCommandType Type { get; set; }
-
-        public Configuration(MultiplayerCommandAttribute? attribute) {
-            Type = attribute?.Type ?? MultiplayerCommandType.Game;
-        }
-
     }
 
 }

--- a/src/MultiplayerMod/Multiplayer/CoreOperations/PlayersManagement/Commands/InitializeClientCommand.cs
+++ b/src/MultiplayerMod/Multiplayer/CoreOperations/PlayersManagement/Commands/InitializeClientCommand.cs
@@ -6,7 +6,7 @@ using MultiplayerMod.Multiplayer.Players;
 namespace MultiplayerMod.Multiplayer.CoreOperations.PlayersManagement.Commands;
 
 [Serializable]
-[MultiplayerCommand(Type = MultiplayerCommandType.System)]
+[MultiplayerCommand(Type = MultiplayerCommandType.System, ExecuteOnServer = true)]
 public class InitializeClientCommand : MultiplayerCommand {
 
     private static Core.Logging.Logger log = LoggerFactory.GetLogger<InitializeClientCommand>();

--- a/src/MultiplayerMod/Multiplayer/CoreOperations/PlayersManagement/Commands/RequestPlayerStateChangeCommand.cs
+++ b/src/MultiplayerMod/Multiplayer/CoreOperations/PlayersManagement/Commands/RequestPlayerStateChangeCommand.cs
@@ -6,7 +6,7 @@ using MultiplayerMod.Network;
 namespace MultiplayerMod.Multiplayer.CoreOperations.PlayersManagement.Commands;
 
 [Serializable]
-[MultiplayerCommand(Type = MultiplayerCommandType.System)]
+[MultiplayerCommand(Type = MultiplayerCommandType.System, ExecuteOnServer = true)]
 public class RequestPlayerStateChangeCommand : MultiplayerCommand {
 
     private PlayerIdentity playerId;

--- a/src/MultiplayerMod/Multiplayer/CoreOperations/PlayersManagement/PlayersManagementController.cs
+++ b/src/MultiplayerMod/Multiplayer/CoreOperations/PlayersManagement/PlayersManagementController.cs
@@ -53,10 +53,7 @@ public class PlayersManagementController {
     }
 
     private void OnCurrentPlayerInitialized(CurrentPlayerInitializedEvent @event) {
-        client.Send(
-            new RequestPlayerStateChangeCommand(@event.Player.Id, PlayerState.Loading),
-            MultiplayerCommandOptions.ExecuteOnServer
-        );
+        client.Send(new RequestPlayerStateChangeCommand(@event.Player.Id, PlayerState.Loading));
         if (@event.Player.Role == PlayerRole.Host)
             server.Send(new ChangePlayerStateCommand(@event.Player.Id, PlayerState.Ready));
         else
@@ -67,8 +64,7 @@ public class PlayersManagementController {
         if (state != MultiplayerClientState.Connected)
             return;
 
-        var command = new InitializeClientCommand(profileProvider.GetPlayerProfile());
-        client.Send(command, MultiplayerCommandOptions.ExecuteOnServer);
+        client.Send(new InitializeClientCommand(profileProvider.GetPlayerProfile()));
     }
 
     private void OnGameStarted(GameStartedEvent @event) {
@@ -76,15 +72,11 @@ public class PlayersManagementController {
             return;
 
         var currentPlayer = @event.Multiplayer.Players.Current;
-        var command = new RequestPlayerStateChangeCommand(currentPlayer.Id, PlayerState.Ready);
-        client.Send(command, MultiplayerCommandOptions.ExecuteOnServer);
+        client.Send(new RequestPlayerStateChangeCommand(currentPlayer.Id, PlayerState.Ready));
     }
 
     private void OnGameQuit(GameQuitEvent @event) {
-        client.Send(
-            new RequestPlayerStateChangeCommand(multiplayer.Players.Current.Id, PlayerState.Leaving),
-            MultiplayerCommandOptions.ExecuteOnServer
-        );
+        client.Send(new RequestPlayerStateChangeCommand(multiplayer.Players.Current.Id, PlayerState.Leaving));
         client.Disconnect();
         multiplayer.Players.Synchronize(Array.Empty<MultiplayerPlayer>());
     }

--- a/src/MultiplayerMod/Network/MultiplayerCommandOptions.cs
+++ b/src/MultiplayerMod/Network/MultiplayerCommandOptions.cs
@@ -11,13 +11,8 @@ public enum MultiplayerCommandOptions {
     None = 0,
 
     /// <summary>
-    /// A command will be executed on the server and will not be forwarded to other clients.
-    /// </summary>
-    ExecuteOnServer = 1,
-
-    /// <summary>
     /// A command will not be sent to host client.
     /// </summary>
-    SkipHost = 2
+    SkipHost = 1
 
 }

--- a/src/MultiplayerMod/Platform/Steam/SteamPlatformConfigurer.cs
+++ b/src/MultiplayerMod/Platform/Steam/SteamPlatformConfigurer.cs
@@ -20,7 +20,7 @@ public class SteamPlatformConfigurer : IModComponentConfigurer {
 
         log.Info("Steam platform detected");
 
-        UnityObject.CreateStaticWithComponent<LobbyJoinRequestComponent>();
+        builder.ContainerCreated += _ => UnityObject.CreateStaticWithComponent<LobbyJoinRequestComponent>();
     }
 
 }


### PR DESCRIPTION
The original approach was overflexible and allowed for the same command to be executed either on a server or a client. But now I see this as an exception from a general principle: one command - one target. 
Now the target is configurable via the `MultiplayerCommand` attribute and it's less error-prone.
(Also it uncovers an issue with platform implementation segregation, we should revise it next QoL iteration)