### PR TITLE
#66 Kick client if server leaves/crashes.

### DIFF
--- a/src/MultiplayerMod.Test/Multiplayer/MultiplayerConnectionTests.cs
+++ b/src/MultiplayerMod.Test/Multiplayer/MultiplayerConnectionTests.cs
@@ -132,7 +132,7 @@ public class MultiplayerConnectionTests {
         clientRuntime.Activate();
 
         if (gracefully) {
-            clientRuntime.EventDispatcher().Dispatch(new GameQuitEvent(clientRuntime.Multiplayer()));
+            clientRuntime.EventDispatcher().Dispatch(new GameQuitEvent());
             Assert.AreEqual(expected: 0, clientRuntime.Multiplayer().Players.Count());
         } else {
             clientRuntime.Dependencies.Get<IMultiplayerClient>().Disconnect();

--- a/src/MultiplayerMod/Multiplayer/CoreOperations/Binders/HostEventsBinder.cs
+++ b/src/MultiplayerMod/Multiplayer/CoreOperations/Binders/HostEventsBinder.cs
@@ -34,7 +34,7 @@ public class HostEventsBinder {
         log.Debug("Binding host events");
 
         eventDispatcher.Subscribe<GameStartedEvent>(OnGameStarted);
-        eventDispatcher.Subscribe<GameQuitEvent>(OnGameQuit);
+        eventDispatcher.Subscribe<StopMultiplayerEvent>(OnStopMultiplayer);
 
         ChoreConsumerEvents.FindNextChore += p => server.Send(new FindNextChore(p), MultiplayerCommandOptions.SkipHost);
     }
@@ -51,7 +51,7 @@ public class HostEventsBinder {
         };
     }
 
-    private void OnGameQuit(GameQuitEvent @event) {
+    private void OnStopMultiplayer(StopMultiplayerEvent @event) {
         if (@event.Multiplayer.Mode != MultiplayerMode.Host)
             return;
 

--- a/src/MultiplayerMod/Multiplayer/CoreOperations/Events/ConnectionLostEvent.cs
+++ b/src/MultiplayerMod/Multiplayer/CoreOperations/Events/ConnectionLostEvent.cs
@@ -1,0 +1,5 @@
+using MultiplayerMod.Core.Events;
+
+namespace MultiplayerMod.Multiplayer.CoreOperations.Events;
+
+public record ConnectionLostEvent : IDispatchableEvent;

--- a/src/MultiplayerMod/Multiplayer/CoreOperations/Events/GameQuitEvent.cs
+++ b/src/MultiplayerMod/Multiplayer/CoreOperations/Events/GameQuitEvent.cs
@@ -2,4 +2,4 @@
 
 namespace MultiplayerMod.Multiplayer.CoreOperations.Events;
 
-public record GameQuitEvent(MultiplayerGame Multiplayer) : IDispatchableEvent;
+public record GameQuitEvent : IDispatchableEvent;

--- a/src/MultiplayerMod/Multiplayer/CoreOperations/Events/StopMultiplayerEvent.cs
+++ b/src/MultiplayerMod/Multiplayer/CoreOperations/Events/StopMultiplayerEvent.cs
@@ -1,0 +1,5 @@
+using MultiplayerMod.Core.Events;
+
+namespace MultiplayerMod.Multiplayer.CoreOperations.Events;
+
+public record StopMultiplayerEvent(MultiplayerGame Multiplayer) : IDispatchableEvent;

--- a/src/MultiplayerMod/Multiplayer/CoreOperations/ExecutionLevelController.cs
+++ b/src/MultiplayerMod/Multiplayer/CoreOperations/ExecutionLevelController.cs
@@ -25,7 +25,7 @@ public class ExecutionLevelController {
         eventDispatcher.Subscribe<SinglePlayerModeSelectedEvent>(OnSinglePlayerModeSelected);
         eventDispatcher.Subscribe<MultiplayerModeSelectedEvent>(OnMultiplayerModeSelected);
         eventDispatcher.Subscribe<PlayerStateChangedEvent>(OnPlayerStateChangedEvent);
-        eventDispatcher.Subscribe<GameQuitEvent>(OnGameQuit);
+        eventDispatcher.Subscribe<StopMultiplayerEvent>(OnStopMultiplayer);
     }
 
     private void OnSinglePlayerModeSelected(SinglePlayerModeSelectedEvent @event) {
@@ -41,7 +41,7 @@ public class ExecutionLevelController {
             executionLevelManager.BaseLevel = ExecutionLevel.Game;
     }
 
-    private void OnGameQuit(GameQuitEvent _) {
+    private void OnStopMultiplayer(StopMultiplayerEvent _) {
         executionLevelManager.BaseLevel = ExecutionLevel.System;
     }
 

--- a/src/MultiplayerMod/Multiplayer/CoreOperations/GameStateEventsRelay.cs
+++ b/src/MultiplayerMod/Multiplayer/CoreOperations/GameStateEventsRelay.cs
@@ -28,7 +28,7 @@ public class GameStateEventsRelay {
 
     private void OnWorldSave() => events.Dispatch(new WorldSavedEvent());
 
-    private void OnGameQuit() => events.Dispatch(new GameQuitEvent(multiplayer));
+    private void OnGameQuit() => events.Dispatch(new GameQuitEvent());
 
     private void OnGameStarted() => scheduler.Run(() => events.Dispatch(new GameStartedEvent(multiplayer)));
 

--- a/src/MultiplayerMod/Multiplayer/CoreOperations/MultiplayerServerController.cs
+++ b/src/MultiplayerMod/Multiplayer/CoreOperations/MultiplayerServerController.cs
@@ -21,7 +21,7 @@ public class MultiplayerServerController {
         this.events = events;
 
         events.Subscribe<GameStartedEvent>(OnGameStarted);
-        events.Subscribe<GameQuitEvent>(OnGameQuit);
+        events.Subscribe<StopMultiplayerEvent>(OnStopMultiplayer);
 
         server.StateChanged += OnServerStateChanged;
     }
@@ -46,7 +46,7 @@ public class MultiplayerServerController {
         server.Start();
     }
 
-    private void OnGameQuit(GameQuitEvent @event) {
+    private void OnStopMultiplayer(StopMultiplayerEvent @event) {
         if (@event.Multiplayer.Mode != MultiplayerMode.Host)
             return;
 

--- a/src/MultiplayerMod/Multiplayer/UI/Notifications.cs
+++ b/src/MultiplayerMod/Multiplayer/UI/Notifications.cs
@@ -1,0 +1,27 @@
+using JetBrains.Annotations;
+using MultiplayerMod.Core.Dependency;
+using MultiplayerMod.Core.Events;
+using MultiplayerMod.Multiplayer.CoreOperations.Events;
+
+namespace MultiplayerMod.Multiplayer.UI;
+
+[Dependency, UsedImplicitly]
+public class Notifications {
+
+    public Notifications(EventDispatcher events) {
+        events.Subscribe<ConnectionLostEvent>(OnConnectionLost);
+    }
+
+    private void OnConnectionLost(ConnectionLostEvent @event) {
+        var screen = (InfoDialogScreen) GameScreenManager.Instance.StartScreen(
+            ScreenPrefabs.Instance.InfoDialogScreen.gameObject,
+            GameScreenManager.Instance.ssOverlayCanvas.gameObject
+        );
+        screen.SetHeader("Multiplayer");
+        screen.AddPlainText("Connection has been lost. Further play can not be synced");
+        screen.AddOption(
+            "OK",
+            _ => PauseScreen.Instance.OnQuitConfirm()
+        );
+    }
+}

--- a/src/MultiplayerMod/Platform/Steam/Network/SteamClient.cs
+++ b/src/MultiplayerMod/Platform/Steam/Network/SteamClient.cs
@@ -64,7 +64,7 @@ public class SteamClient : IMultiplayerClient {
     }
 
     public void Disconnect() {
-        if (State <= MultiplayerClientState.Disconnected)
+        if (State == MultiplayerClientState.Disconnected)
             throw new NetworkPlatformException("Client not connected");
 
         UnityObject.Destroy(gameObject);
@@ -96,8 +96,10 @@ public class SteamClient : IMultiplayerClient {
                     k_nSteamNetworkingSend_Reliable,
                     out var messageOut
                 );
-                if (result != EResult.k_EResultOK && messageOut == 0)
+                if (result != EResult.k_EResultOK || messageOut == 0) {
                     log.Error($"Failed to send {command}: {result}");
+                    SetState(MultiplayerClientState.Error);
+                }
             }
         );
     }


### PR DESCRIPTION
Current implementation does not distinguish between server leave and crash.
![image](https://github.com/onimp/oni_multiplayer/assets/2317493/a7f0834e-ac18-4822-a0cc-9aa8c7c29096)
