### PR TITLE
Fixed msbuild holding dll lock during AttributeProcessor task

### DIFF
--- a/src/MultiplayerMod.AttributeProcessor.MSBuild.Task/ProcessAttributes.cs
+++ b/src/MultiplayerMod.AttributeProcessor.MSBuild.Task/ProcessAttributes.cs
@@ -21,7 +21,9 @@ public class ProcessAttributes : Microsoft.Build.Utilities.Task {
             return ReturnError($"Assembly \"{nameof(AssemblyPath)}\" doesn't exist");
 
         var configuration = Configure(AssemblyPath);
-        var module = ModuleDefMD.Load(configuration.OriginalAssemblyPath);
+        FileStream OriginalAssemblyFile = new FileStream(configuration.OriginalAssemblyPath, FileMode.Open);
+        var module = ModuleDefMD.Load(OriginalAssemblyFile);
+        OriginalAssemblyFile.Close();
         if (GetProcessors(module).Any(processor => !processor.Process()))
             return false;
 

--- a/src/MultiplayerMod.AttributeProcessor.MSBuild.Task/ProcessAttributes.cs
+++ b/src/MultiplayerMod.AttributeProcessor.MSBuild.Task/ProcessAttributes.cs
@@ -21,14 +21,14 @@ public class ProcessAttributes : Microsoft.Build.Utilities.Task {
             return ReturnError($"Assembly \"{nameof(AssemblyPath)}\" doesn't exist");
 
         var configuration = Configure(AssemblyPath);
-        FileStream OriginalAssemblyFile = new FileStream(configuration.OriginalAssemblyPath, FileMode.Open);
-        var module = ModuleDefMD.Load(OriginalAssemblyFile);
-        OriginalAssemblyFile.Close();
-        if (GetProcessors(module).Any(processor => !processor.Process()))
-            return false;
+        using (var module = ModuleDefMD.Load(configuration.OriginalAssemblyPath))
+        {
+            if (GetProcessors(module).Any(processor => !processor.Process()))
+                return false;
 
-        var options = new ModuleWriterOptions(module) { WritePdb = true };
-        module.Write(AssemblyPath, options);
+            var options = new ModuleWriterOptions(module) { WritePdb = true };
+            module.Write(AssemblyPath, options);
+        }
         Cleanup(configuration);
         return true;
     }


### PR DESCRIPTION
For some reason, on my machine, building the solution failed while running the `AttributeProcessor` MSBuild task. The issue being that msbuild.exe held a reference to the `MultiplayerMod.Original.dll` file after opening with `ModuleDefMD.Load()`. It would then fail to delete the file during cleanup. I've simply changed it to open a stream and close it after reading the file. I figured I couldn't be the only one this is affecting. Though in all probability it's something to do with my build environment. Figured I'd throw this up here in case you're interested.

VS2022
x64
Windows 10

Love the mod!