### PR TITLE
#11 Add all chore types to ChoreList. Fix AttackChore causing game failure (wrong GameObject references)

### DIFF
--- a/src/MultiplayerMod.Test/AbstractGameTest.cs
+++ b/src/MultiplayerMod.Test/AbstractGameTest.cs
@@ -6,6 +6,7 @@ using MultiplayerMod.Core.Dependency;
 using MultiplayerMod.ModRuntime;
 using MultiplayerMod.ModRuntime.Context;
 using MultiplayerMod.Multiplayer;
+using MultiplayerMod.Multiplayer.Objects;
 using MultiplayerMod.Test.Environment.Patches;
 using MultiplayerMod.Test.Environment.Unity;
 using MultiplayerMod.Test.Multiplayer.Commands.Chores;
@@ -40,6 +41,7 @@ public abstract class AbstractGameTest {
     protected static GameObject createGameObject() {
         var gameObject = new GameObject();
         gameObject.AddComponent<KMonoBehaviour>();
+        gameObject.AddComponent<MultiplayerInstance>();
         Grid.Objects[Grid.PosToCell(gameObject), 0] = gameObject;
         return gameObject;
     }
@@ -100,6 +102,8 @@ public abstract class AbstractGameTest {
         dependencyContainer.Register(
             new DependencyInfo(nameof(ExecutionContextManager), typeof(ExecutionContextManager), false)
         );
+        dependencyContainer.Register(
+            new DependencyInfo(nameof(DependencyContainer), typeof(DependencyContainer), false));
         new Runtime(dependencyContainer);
         Runtime.Instance.Dependencies.Get<MultiplayerGame>().Refresh(MultiplayerMode.Host);
         Runtime.Instance.Dependencies.Get<ExecutionLevelManager>().EnterOverrideSection(ExecutionLevel.Game);

--- a/src/MultiplayerMod.Test/Game/Chores/ChoreEventsTest.cs
+++ b/src/MultiplayerMod.Test/Game/Chores/ChoreEventsTest.cs
@@ -72,11 +72,11 @@ public class ChoreEventsTest : AbstractGameTest {
                 typeof(DropUnusedInventoryChore),
                 new Func<object[]>(() => new object[] { choreType, target })
             },
-            // new object[] {
-            //     new System.Action(() => new EmoteChore(target, choreType, emote)),
-            //     typeof(EmoteChore),
-            //     new Func<object?[]>(() => new object?[] { target, choreType, emote, 1, null })
-            // },
+            new object[] {
+                new System.Action(() => new EmoteChore(target, choreType, emote)),
+                typeof(EmoteChore),
+                new Func<object?[]>(() => new object?[] { target, choreType, emote, 1, null })
+            },
             new object[] {
                 new System.Action(() => new EquipChore(target)),
                 typeof(EquipChore),
@@ -97,11 +97,11 @@ public class ChoreEventsTest : AbstractGameTest {
                 typeof(MoveToQuarantineChore),
                 new Func<object[]>(() => new object[] { target, target })
             },
-            // new object[] {
-            //     new System.Action(() => new PartyChore(target, medicinalPillWorkable)),
-            //     typeof(PartyChore),
-            //     new Func<object?[]>(() => new object?[] { target, medicinalPillWorkable, null, null, null })
-            // },
+            new object[] {
+                new System.Action(() => new PartyChore(target, medicinalPillWorkable)),
+                typeof(PartyChore),
+                new Func<object?[]>(() => new object?[] { target, medicinalPillWorkable, null, null, null })
+            },
             new object[] {
                 new System.Action(() => new PeeChore(target)),
                 typeof(PeeChore),
@@ -150,15 +150,15 @@ public class ChoreEventsTest : AbstractGameTest {
                 typeof(SighChore),
                 new Func<object[]>(() => new object[] { target })
             },
-            // new object[] {
-            //     new System.Action(
-            //         () => new StressEmoteChore(target, choreType, new HashedString(1), null, KAnim.PlayMode.Loop, null)
-            //     ),
-            //     typeof(StressEmoteChore),
-            //     new Func<object?[]>(
-            //         () => new object?[] { target, choreType, new HashedString(1), null, KAnim.PlayMode.Loop, null }
-            //     )
-            // },
+            new object[] {
+                new System.Action(
+                    () => new StressEmoteChore(target, choreType, new HashedString(1), null, KAnim.PlayMode.Loop, null)
+                ),
+                typeof(StressEmoteChore),
+                new Func<object?[]>(
+                    () => new object?[] { target, choreType, new HashedString(1), null, KAnim.PlayMode.Loop, null }
+                )
+            },
             new object[] {
                 new System.Action(() => new StressIdleChore(target)),
                 typeof(StressIdleChore),
@@ -179,26 +179,26 @@ public class ChoreEventsTest : AbstractGameTest {
                 typeof(TakeOffHatChore),
                 new Func<object[]>(() => new object[] { target, choreType })
             },
-            // new object[] {
-            //     new System.Action(() => new UglyCryChore(choreType, target)),
-            //     typeof(UglyCryChore),
-            //     new Func<object?[]>(() => new object?[] { choreType, target, null })
-            // },
-            // new object[] {
-            //     new System.Action(() => new WaterCoolerChore(target, medicinalPillWorkable)),
-            //     typeof(WaterCoolerChore),
-            //     new Func<object?[]>(() => new object?[] { target, medicinalPillWorkable, null, null, null })
-            // },
-            // new object[] {
-            //     new System.Action(() => new WorkChore<MedicinalPillWorkable>(choreType, medicinalPillWorkable)),
-            //     typeof(WorkChore<MedicinalPillWorkable>),
-            //     new Func<object?[]>(
-            //         () => new object?[] {
-            //             choreType, medicinalPillWorkable, null, true, null, null, null, true, null, false, true, null,
-            //             false, true, true, PriorityScreen.PriorityClass.basic, 5, false, true
-            //         }
-            //     )
-            // }
+            new object[] {
+                new System.Action(() => new UglyCryChore(choreType, target)),
+                typeof(UglyCryChore),
+                new Func<object?[]>(() => new object?[] { choreType, target, null })
+            },
+            new object[] {
+                new System.Action(() => new WaterCoolerChore(target, medicinalPillWorkable)),
+                typeof(WaterCoolerChore),
+                new Func<object?[]>(() => new object?[] { target, medicinalPillWorkable, null, null, null })
+            },
+            new object[] {
+                new System.Action(() => new WorkChore<MedicinalPillWorkable>(choreType, medicinalPillWorkable)),
+                typeof(WorkChore<MedicinalPillWorkable>),
+                new Func<object?[]>(
+                    () => new object?[] {
+                        choreType, medicinalPillWorkable, null, true, null, null, null, true, null, false, true, null,
+                        false, true, true, PriorityScreen.PriorityClass.basic, 5, false, true
+                    }
+                )
+            }
         };
         Assert.AreEqual(ChoreList.DeterministicChores.Count, testArgs.Length);
         return testArgs;

--- a/src/MultiplayerMod.Test/Game/Chores/ChoreEventsTest.cs
+++ b/src/MultiplayerMod.Test/Game/Chores/ChoreEventsTest.cs
@@ -48,7 +48,7 @@ public class ChoreEventsTest : AbstractGameTest {
 
     // ReSharper disable ObjectCreationAsStatement
     private static object[][] GetTestArgs() {
-        var cellCallback = new Func<MoveChore.StatesInstance, int>(_ => 5);
+       // var cellCallback = new Func<MoveChore.StatesInstance, int>(_ => 5);
 
         var testArgs = new[] {
             new object[] {
@@ -72,11 +72,11 @@ public class ChoreEventsTest : AbstractGameTest {
                 typeof(DropUnusedInventoryChore),
                 new Func<object[]>(() => new object[] { choreType, target })
             },
-            new object[] {
-                new System.Action(() => new EmoteChore(target, choreType, emote)),
-                typeof(EmoteChore),
-                new Func<object?[]>(() => new object?[] { target, choreType, emote, 1, null })
-            },
+            // new object[] {
+            //     new System.Action(() => new EmoteChore(target, choreType, emote)),
+            //     typeof(EmoteChore),
+            //     new Func<object?[]>(() => new object?[] { target, choreType, emote, 1, null })
+            // },
             new object[] {
                 new System.Action(() => new EquipChore(target)),
                 typeof(EquipChore),
@@ -87,11 +87,11 @@ public class ChoreEventsTest : AbstractGameTest {
                 typeof(FixedCaptureChore),
                 new Func<object[]>(() => new object[] { kPrefabID })
             },
-            new object[] {
-                new System.Action(() => new MoveChore(target, choreType, cellCallback)),
-                typeof(MoveChore),
-                new Func<object[]>(() => new object[] { target, choreType, cellCallback, false })
-            },
+            // new object[] {
+            //     new System.Action(() => new MoveChore(target, choreType, cellCallback)),
+            //     typeof(MoveChore),
+            //     new Func<object[]>(() => new object[] { target, choreType, cellCallback, false })
+            // },
             new object[] {
                 new System.Action(() => new MoveToQuarantineChore(target, target)),
                 typeof(MoveToQuarantineChore),
@@ -150,15 +150,15 @@ public class ChoreEventsTest : AbstractGameTest {
                 typeof(SighChore),
                 new Func<object[]>(() => new object[] { target })
             },
-            new object[] {
-                new System.Action(
-                    () => new StressEmoteChore(target, choreType, new HashedString(1), null, KAnim.PlayMode.Loop, null)
-                ),
-                typeof(StressEmoteChore),
-                new Func<object?[]>(
-                    () => new object?[] { target, choreType, new HashedString(1), null, KAnim.PlayMode.Loop, null }
-                )
-            },
+            // new object[] {
+            //     new System.Action(
+            //         () => new StressEmoteChore(target, choreType, new HashedString(1), null, KAnim.PlayMode.Loop, null)
+            //     ),
+            //     typeof(StressEmoteChore),
+            //     new Func<object?[]>(
+            //         () => new object?[] { target, choreType, new HashedString(1), null, KAnim.PlayMode.Loop, null }
+            //     )
+            // },
             new object[] {
                 new System.Action(() => new StressIdleChore(target)),
                 typeof(StressIdleChore),

--- a/src/MultiplayerMod.Test/Game/Chores/ChoreListTest.cs
+++ b/src/MultiplayerMod.Test/Game/Chores/ChoreListTest.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+using System.Reflection;
+using MultiplayerMod.Game.Chores;
+using NUnit.Framework;
+
+namespace MultiplayerMod.Test.Game.Chores;
+
+[TestFixture]
+public class ChoreListTest {
+    [Test]
+    public void EnsureChoreListContainsAllChores() {
+        var foundChoreTypes = Assembly.GetAssembly(typeof(Chore))
+            .GetTypes()
+            .Where(
+                type => typeof(Chore).IsAssignableFrom(type)
+                        && type != typeof(Chore)
+                        && type != typeof(Chore<>)
+                        && !type.FullName.Contains("ChoreTableChore")
+            )
+            .OrderBy(a => a.FullName)
+            .ToHashSet();
+
+        Assert.AreEqual(foundChoreTypes, ChoreList.AllChoreTypes);
+    }
+}

--- a/src/MultiplayerMod.Test/Multiplayer/Commands/Chores/CreateHostChoreTest.cs
+++ b/src/MultiplayerMod.Test/Multiplayer/Commands/Chores/CreateHostChoreTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using Database;
 using MultiplayerMod.Game.Chores;
 using MultiplayerMod.Multiplayer.Commands.Chores;
 using MultiplayerMod.Network;
@@ -19,6 +18,8 @@ public class CreateHostChoreTest : AbstractGameTest {
     private static Db db = null!;
     private static KPrefabID kPrefabId = null!;
     private static MedicinalPillWorkable medicineWorkable = null!;
+    private static Constructable constructable = null!;
+    private static TestMonoBehaviour testMonoBehaviour = null!;
 
     [SetUp]
     public new void SetUp() {
@@ -34,10 +35,12 @@ public class CreateHostChoreTest : AbstractGameTest {
         choreType = db.ChoreTypes.Astronaut;
         medicineWorkable = createGameObject().AddComponent<MedicinalPillWorkable>();
         medicineWorkable.Awake();
+        constructable = createGameObject().AddComponent<Constructable>();
+        testMonoBehaviour = createGameObject().AddComponent<TestMonoBehaviour>();
     }
 
     [Test, TestCaseSource(nameof(GetTestArgs))]
-    public void ExecutionTest(Func<CreateNewChoreArgs> getTestArgsFunc) {
+    public void ExecutionTest(Type _, Func<CreateNewChoreArgs> getTestArgsFunc) {
         var arg = getTestArgsFunc.Invoke();
         var command = new CreateHostChore(arg);
 
@@ -45,66 +48,116 @@ public class CreateHostChoreTest : AbstractGameTest {
     }
 
     [Test, TestCaseSource(nameof(GetTestArgs))]
-    public void SerializationTest(Func<CreateNewChoreArgs> getTestArgsFunc) {
+    public void SerializationTest(Type _, Func<CreateNewChoreArgs> getTestArgsFunc) {
         var arg = getTestArgsFunc.Invoke();
         var command = new CreateHostChore(arg);
         var messageFactory = new NetworkMessageFactory();
+        var messageProcessor = new NetworkMessageProcessor();
+        NetworkMessage? networkMessage = null;
 
         var handles = messageFactory.Create(command, MultiplayerCommandOptions.SkipHost).ToArray();
 
-        Assert.NotNull(handles);
+        foreach (var messageHandle in handles) {
+            networkMessage = messageProcessor.Process(1u, messageHandle);
+        }
+        Assert.AreEqual(command.GetType(), networkMessage?.Command.GetType());
+        Assert.AreEqual(command.ChoreType, ((CreateHostChore) networkMessage!.Command).ChoreType);
+        Assert.AreEqual(command.Args, ((CreateHostChore) networkMessage!.Command).Args);
     }
 
     private static object[] GetTestArgs() {
         var result = new object[] {
-            new Func<CreateNewChoreArgs>(
-                () => new CreateNewChoreArgs(typeof(AttackChore), new object[] { target, gameObject })
-            ),
-            new Func<CreateNewChoreArgs>(
-                () => new CreateNewChoreArgs(typeof(DeliverFoodChore), new object[] { target })
-            ),
-            new Func<CreateNewChoreArgs>(
-                () => new CreateNewChoreArgs(typeof(DieChore), new object[] { target, db.Deaths.Frozen })
-            ),
-            new Func<CreateNewChoreArgs>(
-                () => new CreateNewChoreArgs(typeof(DropUnusedInventoryChore), new object[] { choreType, target })
-            ),
-            // new Func<CreateNewChoreArgs>(
-            //     () => new CreateNewChoreArgs(
-            //         typeof(EmoteChore),
-            //         new object?[] { target, choreType, db.Emotes.Minion.Cheer, 1, null }
-            //     )
-            // ),
-            new Func<CreateNewChoreArgs>(() => new CreateNewChoreArgs(typeof(EquipChore), new object[] { target })),
-            new Func<CreateNewChoreArgs>(
-                () => new CreateNewChoreArgs(typeof(FixedCaptureChore), new object[] { kPrefabId })
-            ),
-            new Func<CreateNewChoreArgs>(
-                () => new CreateNewChoreArgs(
-                    typeof(MoveChore),
-                    new object[] { target, choreType, new Func<MoveChore.StatesInstance, int>(_ => 0), false }
+            new object[] {
+                typeof(AttackChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(typeof(AttackChore), new object[] { target, gameObject })
                 )
-            ),
-            new Func<CreateNewChoreArgs>(
-                () => new CreateNewChoreArgs(typeof(MoveToQuarantineChore), new object[] { target, target })
-            ),
-            // new Func<CreateNewChoreArgs>(
-            //     () => new CreateNewChoreArgs(
-            //         typeof(PartyChore),
-            //         new object?[] { target, medicineWorkable, null, null, null }
-            //     )
-            // ),
-            new Func<CreateNewChoreArgs>(() => new CreateNewChoreArgs(typeof(PeeChore), new object[] { target })),
-            new Func<CreateNewChoreArgs>(
-                () => new CreateNewChoreArgs(typeof(PutOnHatChore), new object[] { target, choreType })
-            ),
-            new Func<CreateNewChoreArgs>(
-                () => new CreateNewChoreArgs(typeof(RancherChore), new object[] { kPrefabId })
-            ),
+            },
+            new object[] {
+                typeof(DeliverFoodChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(typeof(DeliverFoodChore), new object[] { target })
+                )
+            },
+            new object[] {
+                typeof(DieChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(typeof(DieChore), new object[] { target, db.Deaths.Frozen })
+                )
+            },
+            new object[] {
+                typeof(DropUnusedInventoryChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(typeof(DropUnusedInventoryChore), new object[] { choreType, target })
+                )
+            },
+            new object[] {
+                typeof(EmoteChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(
+                        typeof(EmoteChore),
+                        new object[]
+                            { target, choreType, db.Emotes.Minion.Cheer, 1, testMonoBehaviour.TestStressEmoteFunc }
+                    )
+                )
+            },
+            new object[] {
+                typeof(EquipChore),
+                new Func<CreateNewChoreArgs>(() => new CreateNewChoreArgs(typeof(EquipChore), new object[] { target }))
+            },
+            new object[] {
+                typeof(FixedCaptureChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(typeof(FixedCaptureChore), new object[] { kPrefabId })
+                )
+            },
+            new object[] {
+                typeof(MoveChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(
+                        typeof(MoveChore),
+                        new object[] { target, choreType, testMonoBehaviour.TestMoveFunc, false }
+                    )
+                )
+            },
+            new object[] {
+                typeof(MoveToQuarantineChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(typeof(MoveToQuarantineChore), new object[] { target, target })
+                )
+            },
+            new object[] {
+                typeof(PartyChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(
+                        typeof(PartyChore),
+                        new object[] {
+                            target, medicineWorkable, constructable.UpdateBuildState, constructable.UpdateBuildState,
+                            constructable.UpdateBuildState
+                        }
+                    )
+                )
+            },
+            new object[] {
+                typeof(PeeChore),
+                new Func<CreateNewChoreArgs>(() => new CreateNewChoreArgs(typeof(PeeChore), new object[] { target }))
+            },
+            new object[] {
+                typeof(PutOnHatChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(typeof(PutOnHatChore), new object[] { target, choreType })
+                )
+            },
+            new object[] {
+                typeof(RancherChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(typeof(RancherChore), new object[] { kPrefabId })
+                )
+            },
             // new Func<CreateNewChoreArgs>(
             //     () => new CreateNewChoreArgs(
             //         typeof(ReactEmoteChore),
-            //         new object?[] {
+            //         new object[] {
             //             target, choreType,
             //             new EmoteReactable(
             //                 gameObject,
@@ -119,60 +172,115 @@ public class CreateHostChoreTest : AbstractGameTest {
             //         }
             //     )
             // ),
-            new Func<CreateNewChoreArgs>(
-                () => new CreateNewChoreArgs(typeof(RescueIncapacitatedChore), new object[] { target, gameObject })
-            ),
-            new Func<CreateNewChoreArgs>(
-                () => new CreateNewChoreArgs(
-                    typeof(RescueSweepBotChore),
-                    new object[] { target, gameObject, gameObject }
+            new object[] {
+                typeof(RescueIncapacitatedChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(typeof(RescueIncapacitatedChore), new object[] { target, gameObject })
                 )
-            ),
-            new Func<CreateNewChoreArgs>(() => new CreateNewChoreArgs(typeof(SighChore), new object[] { target })),
-            // new Func<CreateNewChoreArgs>(
-            //     () => new CreateNewChoreArgs(
-            //         typeof(StressEmoteChore),
-            //         new object?[] {
-            //             target, choreType, new HashedString(1), new HashedString[] { new(2) }, KAnim.PlayMode.Paused,
-            //             null
-            //         }
-            //     )
-            // ),
-            new Func<CreateNewChoreArgs>(
-                () => new CreateNewChoreArgs(typeof(StressIdleChore), new object[] { target })
-            ),
-            new Func<CreateNewChoreArgs>(
-                () => new CreateNewChoreArgs(typeof(SwitchRoleHatChore), new object[] { target, choreType })
-            ),
-            new Func<CreateNewChoreArgs>(
-                () => new CreateNewChoreArgs(typeof(TakeMedicineChore), new object[] { medicineWorkable })
-            ),
-            new Func<CreateNewChoreArgs>(
-                () => new CreateNewChoreArgs(typeof(TakeOffHatChore), new object[] { target, choreType })
-            ),
-            // new Func<CreateNewChoreArgs>(
-            //     () => new CreateNewChoreArgs(typeof(UglyCryChore), new object?[] { choreType, target, null })
-            // ),
-            // new Func<CreateNewChoreArgs>(
-            //     () => new CreateNewChoreArgs(
-            //         typeof(WaterCoolerChore),
-            //         new object?[] { target, medicineWorkable, null, null, null }
-            //     )
-            // ),
-            // new Func<CreateNewChoreArgs>(
-            //     () => new CreateNewChoreArgs(
-            //         typeof(WorkChore<MedicinalPillWorkable>),
-            //         new object?[] {
-            //             choreType, medicineWorkable, createGameObject().AddComponent<ChoreProvider>(), false, null,
-            //             null, null, false, db.ScheduleBlockTypes.Work, true,
-            //             false, Assets.GetAnim("anim_interacts_medicine_nuclear_kanim"), true, false, false,
-            //             PriorityScreen.PriorityClass.high, 6, true, false
-            //         }
-            //     )
-            // )
+            },
+            new object[] {
+                typeof(RescueSweepBotChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(
+                        typeof(RescueSweepBotChore),
+                        new object[] { target, gameObject, gameObject }
+                    )
+                )
+            },
+            new object[] {
+                typeof(SighChore),
+                new Func<CreateNewChoreArgs>(() => new CreateNewChoreArgs(typeof(SighChore), new object[] { target }))
+            },
+            new object[] {
+                typeof(StressEmoteChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(
+                        typeof(StressEmoteChore),
+                        new object[] {
+                            target, choreType, new HashedString(1), new HashedString[] { new(2) },
+                            KAnim.PlayMode.Paused, testMonoBehaviour.TestStressEmoteFunc
+                        }
+                    )
+                )
+            },
+            new object[] {
+                typeof(StressIdleChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(typeof(StressIdleChore), new object[] { target })
+                )
+            },
+            new object[] {
+                typeof(SwitchRoleHatChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(typeof(SwitchRoleHatChore), new object[] { target, choreType })
+                )
+            },
+            new object[] {
+                typeof(TakeMedicineChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(typeof(TakeMedicineChore), new object[] { medicineWorkable })
+                )
+            },
+            new object[] {
+                typeof(TakeOffHatChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(typeof(TakeOffHatChore), new object[] { target, choreType })
+                )
+            },
+
+            new object[] {
+                typeof(UglyCryChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(
+                        typeof(UglyCryChore),
+                        new object[] { choreType, target, constructable.UpdateBuildState }
+                    )
+                )
+            },
+            new object[] {
+                typeof(WaterCoolerChore),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(
+                        typeof(WaterCoolerChore),
+                        new object[] {
+                            target, medicineWorkable, constructable.UpdateBuildState, constructable.UpdateBuildState,
+                            constructable.UpdateBuildState
+                        }
+                    )
+                )
+            },
+            new object[] {
+                typeof(WorkChore<MedicinalPillWorkable>),
+                new Func<CreateNewChoreArgs>(
+                    () => new CreateNewChoreArgs(
+                        typeof(WorkChore<MedicinalPillWorkable>),
+                        new object[] {
+                            choreType, medicineWorkable, createGameObject().AddComponent<ChoreProvider>(), false,
+                            constructable.UpdateBuildState, constructable.UpdateBuildState,
+                            constructable.UpdateBuildState,
+                            false,
+                            db.ScheduleBlockTypes.Work, true, false,
+                            Assets.GetAnim("anim_interacts_medicine_nuclear_kanim"), true, false, false,
+                            PriorityScreen.PriorityClass.high, 6, true, false
+                        }
+                    )
+                )
+            }
         };
         Assert.AreEqual(result.Length, ChoreList.DeterministicChores.Count);
 
         return result;
     }
+
+    private class TestMonoBehaviour : KMonoBehaviour {
+
+        public int TestMoveFunc(object obj) {
+            return 0;
+        }
+
+        public StatusItem TestStressEmoteFunc() {
+            return new StatusItem("", "");
+        }
+    }
+
 }

--- a/src/MultiplayerMod.Test/Multiplayer/Commands/Chores/CreateHostChoreTest.cs
+++ b/src/MultiplayerMod.Test/Multiplayer/Commands/Chores/CreateHostChoreTest.cs
@@ -19,7 +19,7 @@ public class CreateHostChoreTest : AbstractGameTest {
     private static KPrefabID kPrefabId = null!;
     private static MedicinalPillWorkable medicineWorkable = null!;
     private static Constructable constructable = null!;
-    private static TestMonoBehaviour testMonoBehaviour = null!;
+ //   private static TestMonoBehaviour testMonoBehaviour = null!;
 
     [SetUp]
     public new void SetUp() {
@@ -36,7 +36,7 @@ public class CreateHostChoreTest : AbstractGameTest {
         medicineWorkable = createGameObject().AddComponent<MedicinalPillWorkable>();
         medicineWorkable.Awake();
         constructable = createGameObject().AddComponent<Constructable>();
-        testMonoBehaviour = createGameObject().AddComponent<TestMonoBehaviour>();
+     //   testMonoBehaviour = createGameObject().AddComponent<TestMonoBehaviour>();
     }
 
     [Test, TestCaseSource(nameof(GetTestArgs))]
@@ -65,6 +65,7 @@ public class CreateHostChoreTest : AbstractGameTest {
         Assert.AreEqual(command.Args, ((CreateHostChore) networkMessage!.Command).Args);
     }
 
+#pragma warning disable CS8974 // Converting method group to non-delegate type
     private static object[] GetTestArgs() {
         var result = new object[] {
             new object[] {
@@ -91,16 +92,16 @@ public class CreateHostChoreTest : AbstractGameTest {
                     () => new CreateNewChoreArgs(typeof(DropUnusedInventoryChore), new object[] { choreType, target })
                 )
             },
-            new object[] {
-                typeof(EmoteChore),
-                new Func<CreateNewChoreArgs>(
-                    () => new CreateNewChoreArgs(
-                        typeof(EmoteChore),
-                        new object[]
-                            { target, choreType, db.Emotes.Minion.Cheer, 1, testMonoBehaviour.TestStressEmoteFunc }
-                    )
-                )
-            },
+            // new object[] {
+            //     typeof(EmoteChore),
+            //     new Func<CreateNewChoreArgs>(
+            //         () => new CreateNewChoreArgs(
+            //             typeof(EmoteChore),
+            //             new object[]
+            //                 { target, choreType, db.Emotes.Minion.Cheer, 1, testMonoBehaviour.TestStressEmoteFunc }
+            //         )
+            //     )
+            // },
             new object[] {
                 typeof(EquipChore),
                 new Func<CreateNewChoreArgs>(() => new CreateNewChoreArgs(typeof(EquipChore), new object[] { target }))
@@ -111,15 +112,15 @@ public class CreateHostChoreTest : AbstractGameTest {
                     () => new CreateNewChoreArgs(typeof(FixedCaptureChore), new object[] { kPrefabId })
                 )
             },
-            new object[] {
-                typeof(MoveChore),
-                new Func<CreateNewChoreArgs>(
-                    () => new CreateNewChoreArgs(
-                        typeof(MoveChore),
-                        new object[] { target, choreType, testMonoBehaviour.TestMoveFunc, false }
-                    )
-                )
-            },
+            // new object[] {
+            //     typeof(MoveChore),
+            //     new Func<CreateNewChoreArgs>(
+            //         () => new CreateNewChoreArgs(
+            //             typeof(MoveChore),
+            //             new object[] { target, choreType, testMonoBehaviour.TestMoveFunc, false }
+            //         )
+            //     )
+            // },
             new object[] {
                 typeof(MoveToQuarantineChore),
                 new Func<CreateNewChoreArgs>(
@@ -191,18 +192,18 @@ public class CreateHostChoreTest : AbstractGameTest {
                 typeof(SighChore),
                 new Func<CreateNewChoreArgs>(() => new CreateNewChoreArgs(typeof(SighChore), new object[] { target }))
             },
-            new object[] {
-                typeof(StressEmoteChore),
-                new Func<CreateNewChoreArgs>(
-                    () => new CreateNewChoreArgs(
-                        typeof(StressEmoteChore),
-                        new object[] {
-                            target, choreType, new HashedString(1), new HashedString[] { new(2) },
-                            KAnim.PlayMode.Paused, testMonoBehaviour.TestStressEmoteFunc
-                        }
-                    )
-                )
-            },
+            // new object[] {
+            //     typeof(StressEmoteChore),
+            //     new Func<CreateNewChoreArgs>(
+            //         () => new CreateNewChoreArgs(
+            //             typeof(StressEmoteChore),
+            //             new object[] {
+            //                 target, choreType, new HashedString(1), new HashedString[] { new(2) },
+            //                 KAnim.PlayMode.Paused, testMonoBehaviour.TestStressEmoteFunc
+            //             }
+            //         )
+            //     )
+            // },
             new object[] {
                 typeof(StressIdleChore),
                 new Func<CreateNewChoreArgs>(
@@ -271,16 +272,17 @@ public class CreateHostChoreTest : AbstractGameTest {
 
         return result;
     }
+#pragma warning restore CS8974 // Converting method group to non-delegate type
 
-    private class TestMonoBehaviour : KMonoBehaviour {
-
-        public int TestMoveFunc(object obj) {
-            return 0;
-        }
-
-        public StatusItem TestStressEmoteFunc() {
-            return new StatusItem("", "");
-        }
-    }
+    // private class TestMonoBehaviour : KMonoBehaviour {
+    //
+    //     public int TestMoveFunc(object obj) {
+    //         return 0;
+    //     }
+    //
+    //     public StatusItem TestStressEmoteFunc() {
+    //         return new StatusItem("", "");
+    //     }
+    // }
 
 }

--- a/src/MultiplayerMod.Test/MultiplayerMod.Test.csproj
+++ b/src/MultiplayerMod.Test/MultiplayerMod.Test.csproj
@@ -33,6 +33,9 @@
         <Reference Include="Unity.TextMeshPro" HintPath="$(ManagedPath)\Unity.TextMeshPro.dll"/>
         <Reference Include="com.rlabrecque.steamworks.net" HintPath="$(ManagedPath)\com.rlabrecque.steamworks.net.dll"/>
         <Reference Include="ImGui.NET" HintPath="$(ManagedPath)\ImGui.NET.dll"/>
+        <Reference Include="ImGui" HintPath="$(ManagedPath)\ImGui.dll"/>
+        <Reference Include="LibNoiseDotNet" HintPath="$(ManagedPath)\LibNoiseDotNet.dll"/>
+        <Reference Include="Ionic.Zip" HintPath="$(ManagedPath)\Ionic.Zip.dll"/>
         <Reference Include="Newtonsoft.Json" HintPath="$(ManagedPath)\Newtonsoft.Json.dll"/>
     </ItemGroup>
 </Project>

--- a/src/MultiplayerMod/Game/Chores/ChoreEvents.cs
+++ b/src/MultiplayerMod/Game/Chores/ChoreEvents.cs
@@ -13,13 +13,11 @@ namespace MultiplayerMod.Game.Chores;
 [HarmonyPatch]
 public static class ChoreEvents {
 
-    private static readonly HashSet<Type> supportedChores = new(ChoreList.DeterministicChores);
-
     public static event Action<CreateNewChoreArgs>? CreateNewChore;
 
     [UsedImplicitly]
     private static IEnumerable<MethodBase> TargetMethods() {
-        return supportedChores
+        return ChoreList.SupportedChores
             .Select(
                 type => {
                     if (!type.IsGenericType) return type.GetConstructors()[0];
@@ -37,8 +35,8 @@ public static class ChoreEvents {
     [RequireMultiplayerMode(MultiplayerMode.Host)]
     private static void Chore_Constructor(Chore __instance, object[] __args) {
         var type = __instance.GetType();
-        if (!supportedChores.Contains(type) &&
-            !(type.IsGenericType && supportedChores.Contains(type.GetGenericTypeDefinition()))) {
+        if (!ChoreList.SupportedChores.Contains(type) &&
+            !(type.IsGenericType && ChoreList.SupportedChores.Contains(type.GetGenericTypeDefinition()))) {
             return;
         }
 

--- a/src/MultiplayerMod/Game/Chores/ChoreList.cs
+++ b/src/MultiplayerMod/Game/Chores/ChoreList.cs
@@ -4,42 +4,46 @@ using System.Collections.Generic;
 namespace MultiplayerMod.Game.Chores;
 
 public static class ChoreList {
+
+
     public static readonly HashSet<Type> DeterministicChores = new(
         new[] {
             typeof(AttackChore),
             typeof(DeliverFoodChore),
             typeof(DieChore),
             typeof(DropUnusedInventoryChore),
+            typeof(EmoteChore),
             typeof(EquipChore),
             typeof(FixedCaptureChore),
             typeof(MoveChore),
             typeof(MoveToQuarantineChore),
+            typeof(PartyChore),
             typeof(PeeChore),
             typeof(PutOnHatChore),
             typeof(RancherChore),
             typeof(RescueIncapacitatedChore),
             typeof(RescueSweepBotChore),
             typeof(SighChore),
+            typeof(StressEmoteChore),
             typeof(StressIdleChore),
             typeof(SwitchRoleHatChore),
             typeof(TakeMedicineChore),
             typeof(TakeOffHatChore),
+            typeof(UglyCryChore),
+            typeof(WaterCoolerChore),
+            typeof(WorkChore<>),
         }
     );
+
     // Those chore have some issues and are disabled for now.
     public static readonly HashSet<Type> DeterministicChoresOff = new(
         new[] {
             // No usage has been found in the game dlls.
             // one argument of type EmoteReactable is not serializable.
-            typeof(ReactEmoteChore),
-            // Chores below has Function / Action as one of arguments
-            typeof(EmoteChore),
-            typeof(PartyChore),
-            typeof(StressEmoteChore),
-            typeof(UglyCryChore),
-            typeof(WaterCoolerChore),
-            typeof(WorkChore<>)
+            typeof(ReactEmoteChore)
         }
     );
+
+    public static readonly HashSet<Type> SupportedChores = new(DeterministicChores);
 
 }

--- a/src/MultiplayerMod/Game/Chores/ChoreList.cs
+++ b/src/MultiplayerMod/Game/Chores/ChoreList.cs
@@ -1,21 +1,22 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MultiplayerMod.Game.Chores;
 
 public static class ChoreList {
 
-
+    /**
+     * Those chores are fully determined by the input.
+     */
     public static readonly HashSet<Type> DeterministicChores = new(
         new[] {
             typeof(AttackChore),
             typeof(DeliverFoodChore),
             typeof(DieChore),
             typeof(DropUnusedInventoryChore),
-            typeof(EmoteChore),
             typeof(EquipChore),
             typeof(FixedCaptureChore),
-            typeof(MoveChore),
             typeof(MoveToQuarantineChore),
             typeof(PartyChore),
             typeof(PeeChore),
@@ -24,7 +25,6 @@ public static class ChoreList {
             typeof(RescueIncapacitatedChore),
             typeof(RescueSweepBotChore),
             typeof(SighChore),
-            typeof(StressEmoteChore),
             typeof(StressIdleChore),
             typeof(SwitchRoleHatChore),
             typeof(TakeMedicineChore),
@@ -35,7 +35,9 @@ public static class ChoreList {
         }
     );
 
-    // Those chore have some issues and are disabled for now.
+    /**
+     * Those chores have some issues and are disabled for now.
+     */
     public static readonly HashSet<Type> DeterministicChoresOff = new(
         new[] {
             // No usage has been found in the game dlls.
@@ -46,4 +48,44 @@ public static class ChoreList {
 
     public static readonly HashSet<Type> SupportedChores = new(DeterministicChores);
 
+    /**
+     * Those chores changes its parameters dynamically via target parameters.
+     */
+    public static readonly HashSet<Type> DynamicTargetedChores = new(
+        new[] {
+            typeof(AggressiveChore),
+            typeof(BeIncapacitatedChore),
+            typeof(BingeEatChore),
+            typeof(EatChore),
+            typeof(EmoteChore),
+            typeof(EntombedChore),
+            typeof(FetchAreaChore),
+            typeof(FleeChore),
+            typeof(FoodFightChore),
+            typeof(MoveChore),
+            typeof(MournChore),
+            typeof(MovePickupableChore),
+            typeof(MoveToSafetyChore),
+            typeof(RecoverBreathChore),
+            typeof(SleepChore),
+            typeof(StressEmoteChore),
+        }
+    );
+
+    /**
+     * Those chores changes its parameters dynamically without using target parameters.
+     */
+    public static readonly HashSet<Type> DynamicNonTargetedChores = new(
+        new[] {
+            typeof(BalloonArtistChore),
+            typeof(BansheeChore),
+            typeof(FetchChore),
+            typeof(IdleChore),
+            typeof(MingleChore),
+            typeof(VomitChore),
+        }
+    );
+
+    public static readonly IEnumerable<Type> AllChoreTypes = DeterministicChores.Concat(DeterministicChoresOff)
+        .Concat(DynamicTargetedChores).Concat(DynamicNonTargetedChores).OrderBy(a => a.FullName).ToList();
 }

--- a/src/MultiplayerMod/Game/Mechanics/Objects/ObjectEvents.cs
+++ b/src/MultiplayerMod/Game/Mechanics/Objects/ObjectEvents.cs
@@ -140,7 +140,7 @@ public static class ObjectEvents {
         var args = __args.Select(
             obj =>
                 obj switch {
-                    GameObject gameObject => gameObject.GetGridReference(),
+                    GameObject gameObject => gameObject.GetReference(),
                     KMonoBehaviour kMonoBehaviour => kMonoBehaviour.GetReference(),
                     _ => obj
                 }

--- a/src/MultiplayerMod/Multiplayer/Commands/Chores/CreateHostChore.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Chores/CreateHostChore.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Linq;
+using System.Reflection;
 using MultiplayerMod.Game.Chores;
-using MultiplayerMod.ModRuntime.Context;
-using MultiplayerMod.ModRuntime.StaticCompatibility;
 using MultiplayerMod.Multiplayer.Objects;
 using MultiplayerMod.Multiplayer.Objects.Reference;
 using UnityEngine;
@@ -12,31 +11,46 @@ namespace MultiplayerMod.Multiplayer.Commands.Chores;
 [Serializable]
 public class CreateHostChore : MultiplayerCommand {
 
-    private readonly Type choreType;
-    private readonly object?[] args;
+    public readonly Type ChoreType;
+    public readonly object?[] Args;
 
     public CreateHostChore(CreateNewChoreArgs args) {
-        this.choreType = args.ChoreType;
-        this.args = args.Args.Select(
-            obj =>
-                obj switch {
-                    GameObject gameObject => gameObject.GetGridReference(),
-                    KMonoBehaviour kMonoBehaviour => kMonoBehaviour.GetReference(),
-                    _ => obj
-                }
-        ).ToArray();
+        ChoreType = args.ChoreType;
+        Args = args.Args.Select(WrapObject).ToArray();
     }
 
     public override void Execute(MultiplayerCommandContext context) {
-        var args = this.args.Select(
-            arg =>
-                arg switch {
-                    GameObjectReference gameObjectReference => gameObjectReference.GetGameObject(),
-                    ComponentReference reference => reference.GetComponent(),
-                    _ => arg
-                }
-        ).ToArray();
+        var args = Args.Select(UnWrapObject).ToArray();
 
-        Activator.CreateInstance(choreType, args);
+        ChoreType.GetConstructors()[0].Invoke(args);
     }
+
+    private object? WrapObject(object? obj) {
+        return obj switch {
+            GameObject gameObject => gameObject.GetReference(),
+            KMonoBehaviour kMonoBehaviour => kMonoBehaviour.GetReference(),
+            Delegate action => new DelegateRef(action.GetType(), WrapObject(action.Target), action.Method),
+            _ => obj
+        };
+    }
+
+    private object? UnWrapObject(object? obj) {
+        return obj switch {
+            GameObjectReference gameObjectReference => gameObjectReference.GetGameObject(),
+            ComponentReference reference => reference.GetComponent(),
+            DelegateRef delegateRef => Delegate.CreateDelegate(
+                delegateRef.DelegateType,
+                UnWrapObject(delegateRef.Target),
+                delegateRef.MethodInfo
+            ),
+            _ => obj
+        };
+    }
+
+    [Serializable]
+    public record DelegateRef(
+        Type DelegateType,
+        object? Target,
+        MethodInfo MethodInfo
+    );
 }

--- a/src/MultiplayerMod/Multiplayer/Commands/Screens/Consumable/PermitConsumableToMinion.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Screens/Consumable/PermitConsumableToMinion.cs
@@ -14,7 +14,7 @@ public class PermitConsumableToMinion : MultiplayerCommand {
     private readonly bool isAllowed;
 
     public PermitConsumableToMinion(ConsumableConsumer consumableConsumer, string consumableId, bool isAllowed) {
-        consumableConsumerReference = consumableConsumer.gameObject.GetMultiplayerReference();
+        consumableConsumerReference = consumableConsumer.gameObject.GetReference();
         this.consumableId = consumableId;
         this.isAllowed = isAllowed;
     }

--- a/src/MultiplayerMod/Multiplayer/Commands/Screens/Priorities/SetPersonalPriority.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Screens/Priorities/SetPersonalPriority.cs
@@ -17,7 +17,7 @@ public class SetPersonalPriority : MultiplayerCommand {
         Db.Get().ChoreGroups.resources.FirstOrDefault(resource => resource.Id == choreGroupId);
 
     public SetPersonalPriority(ChoreConsumer choreConsumer, ChoreGroup choreGroup, int value) {
-        choreConsumerReference = choreConsumer.gameObject.GetMultiplayerReference();
+        choreConsumerReference = choreConsumer.gameObject.GetReference();
         choreGroupId = choreGroup.Id;
         this.value = value;
     }

--- a/src/MultiplayerMod/Multiplayer/Commands/Screens/Skill/MasterSkill.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Screens/Skill/MasterSkill.cs
@@ -11,7 +11,7 @@ public class MasterSkill : MultiplayerCommand {
     private readonly string skillId;
 
     public MasterSkill(MinionIdentity minionIdentity, string skillId) {
-        minionIdentityReference = minionIdentity.gameObject.GetMultiplayerReference();
+        minionIdentityReference = minionIdentity.gameObject.GetReference();
         this.skillId = skillId;
     }
 

--- a/src/MultiplayerMod/Multiplayer/Commands/Screens/Skill/SetHat.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Screens/Skill/SetHat.cs
@@ -11,7 +11,7 @@ public class SetHat : MultiplayerCommand {
     private readonly string? targetHat;
 
     public SetHat(MinionIdentity minionIdentity, string? targetHat) {
-        minionIdentityReference = minionIdentity.gameObject.GetMultiplayerReference();
+        minionIdentityReference = minionIdentity.gameObject.GetReference();
         this.targetHat = targetHat;
     }
 

--- a/src/MultiplayerMod/Multiplayer/Objects/ComponentReferenceExtensions.cs
+++ b/src/MultiplayerMod/Multiplayer/Objects/ComponentReferenceExtensions.cs
@@ -1,34 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using MultiplayerMod.Multiplayer.Objects.Reference;
 
 namespace MultiplayerMod.Multiplayer.Objects;
 
 public static class ComponentReferenceExtensions {
 
-    private static readonly HashSet<Type> movableObjectTypes = new() {
-        typeof(MinionAssignablesProxy),
-        typeof(MinionResume),
-        typeof(Schedulable),
-        typeof(ConsumableConsumer),
-        typeof(ChoreConsumer)
-    };
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ComponentReference GetReference(this KMonoBehaviour component) => new(
+        component.gameObject.GetReference(),
+        component.GetType()
+    );
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ComponentReference GetReference(this KMonoBehaviour component)
-        => component.Movable()
-            ? new ComponentReference(component.gameObject.GetMultiplayerReference(), component.GetType())
-            : new ComponentReference(component.gameObject.GetGridReference(), component.GetType());
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ComponentReference<T> GetReference<T>(this T component) where T : KMonoBehaviour
-        => component.Movable()
-            ? new ComponentReference<T>(component.gameObject.GetMultiplayerReference())
-            : new ComponentReference<T>(component.gameObject.GetGridReference());
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool Movable(this KMonoBehaviour kMonoBehaviour) =>
-        movableObjectTypes.Contains(kMonoBehaviour.GetType());
-
+    public static ComponentReference<T> GetReference<T>(this T component) where T : KMonoBehaviour =>
+        new(component.gameObject.GetReference());
 }

--- a/src/MultiplayerMod/Multiplayer/Objects/GameObjectExtensions.cs
+++ b/src/MultiplayerMod/Multiplayer/Objects/GameObjectExtensions.cs
@@ -7,14 +7,6 @@ namespace MultiplayerMod.Multiplayer.Objects;
 public static class GameObjectExtensions {
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static GameObjectReference GetMultiplayerReference(this GameObject gameObject) =>
-        new MultiplayerIdReference(gameObject.GetComponent<MultiplayerInstance>().Id!);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static GameObjectReference GetGridReference(this GameObject gameObject) =>
-        new GridReference(gameObject);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static GameObjectReference GetReference(this GameObject gameObject) {
         var multiplayerId = gameObject.GetComponent<MultiplayerInstance>().Id;
         if (multiplayerId != null)

--- a/src/MultiplayerMod/Multiplayer/Objects/Reference/ComponentReference.cs
+++ b/src/MultiplayerMod/Multiplayer/Objects/Reference/ComponentReference.cs
@@ -16,6 +16,24 @@ public class ComponentReference {
 
     public Component? GetComponent() => GameObjectReference.GetComponent(ComponentType);
 
+    protected bool Equals(ComponentReference other) {
+        return GameObjectReference.Equals(other.GameObjectReference) && ComponentType == other.ComponentType;
+    }
+
+    public override bool Equals(object? obj) {
+        if (ReferenceEquals(null, obj)) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != this.GetType()) return false;
+
+        return Equals((ComponentReference) obj);
+    }
+
+    public override int GetHashCode() {
+        unchecked {
+            return (GameObjectReference.GetHashCode() * 397) ^ ComponentType.GetHashCode();
+        }
+    }
+
 }
 
 [Serializable]

--- a/src/MultiplayerMod/Multiplayer/Patches/DisableClientChorePatch.cs
+++ b/src/MultiplayerMod/Multiplayer/Patches/DisableClientChorePatch.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 using HarmonyLib;
@@ -7,15 +6,12 @@ using MultiplayerMod.Core.Scheduling;
 using MultiplayerMod.Game.Chores;
 using MultiplayerMod.ModRuntime;
 using MultiplayerMod.ModRuntime.Context;
-using MultiplayerMod.ModRuntime.StaticCompatibility;
 using MultiplayerMod.Multiplayer.CoreOperations;
 
 namespace MultiplayerMod.Multiplayer.Patches;
 
 [HarmonyPatch(typeof(Chore))]
 public static class DisableClientChorePatch {
-
-    private static readonly HashSet<Type> supportedChores = new(ChoreList.DeterministicChores);
 
     [UsedImplicitly]
     private static IEnumerable<MethodBase> TargetMethods() => new[] { typeof(Chore).GetConstructors()[0] };
@@ -26,8 +22,8 @@ public static class DisableClientChorePatch {
     [RequireExecutionLevel(ExecutionLevel.Game)]
     private static void Chore_Constructor(Chore __instance, object[] __args) {
         var type = __instance.GetType();
-        if (!supportedChores.Contains(type) &&
-            !(type.IsGenericType && supportedChores.Contains(type.GetGenericTypeDefinition()))) {
+        if (!ChoreList.SupportedChores.Contains(type) &&
+            !(type.IsGenericType && ChoreList.SupportedChores.Contains(type.GetGenericTypeDefinition()))) {
             return;
         }
 

--- a/src/MultiplayerMod/Platform/Steam/Network/Messaging/Surrogates/EmoteSurrogate.cs
+++ b/src/MultiplayerMod/Platform/Steam/Network/Messaging/Surrogates/EmoteSurrogate.cs
@@ -20,6 +20,6 @@ public class EmoteSurrogate : ISerializationSurrogate, ISurrogateType {
         ISurrogateSelector selector
     ) {
         var id = info.GetString("id");
-        return Db.Get().Emotes.Get(id);
+        return Db.Get().Emotes.Minion.Get(id);
     }
 }


### PR DESCRIPTION
Also disabled chores with Func arguments since some of them can not be serialised (MoveChore has lambda and Delegate's Target is not replaced with a reference)