### PR TITLE
#13 Send and execute command upon state enter transition.

### DIFF
--- a/src/MultiplayerMod.Test/Game/Chores/States/ChoreStateEventsTest.cs
+++ b/src/MultiplayerMod.Test/Game/Chores/States/ChoreStateEventsTest.cs
@@ -34,6 +34,7 @@ public class ChoreStateEventsTest : AbstractChoreTest {
         var chore = CreateChore(choreType, choreArgsFunc.Invoke());
         var smi = (StateMachine.Instance) chore.GetType().GetProperty("smi").GetValue(chore);
         var state = config.GetMonitoredState(smi.stateMachine);
+        state.defaultState = null;
         var amountInstance = new AmountInstance(Db.Get().Amounts.Calories, Minion.gameObject);
         amountInstance.maxAttribute.Attribute.BaseValue = 50;
         Minion.gameObject.GetAmounts().ModifierList.Add(amountInstance);
@@ -51,6 +52,10 @@ public class ChoreStateEventsTest : AbstractChoreTest {
         var expectedDictionary = expectedDictionaryFunc.Invoke();
         Assert.NotNull(firedArgs);
         Assert.AreEqual(chore, firedArgs!.Chore);
+        Assert.AreEqual(
+            config.StateToMonitorName != "root" ? "root." + config.StateToMonitorName : config.StateToMonitorName,
+            firedArgs!.TargetState
+        );
         Assert.AreEqual(expectedDictionary.Keys, firedArgs!.Args.Keys);
         Assert.AreEqual(
             expectedDictionary.Values.Select(it => it?.GetType()).ToArray(),

--- a/src/MultiplayerMod.Test/Multiplayer/Patches/Chores/States/DisableChoreStateTransitionTest.cs
+++ b/src/MultiplayerMod.Test/Multiplayer/Patches/Chores/States/DisableChoreStateTransitionTest.cs
@@ -36,13 +36,15 @@ public class DisableChoreStateTransitionTest : AbstractChoreTest {
         StateTransitionConfig config
     ) {
         var statesManager = Runtime.Instance.Dependencies.Get<FakeStatesManager>();
-        statesManager.CalledWithStates.Clear();
+        statesManager.WaitArgs.Clear();
+        statesManager.ContinuationArgs.Clear();
 
         var chore = CreateChore(choreType, choreArgsFunc.Invoke());
 
         var smi = statesManager.GetSmi(chore);
-        var expectedState = config.GetMonitoredState(smi.stateMachine);
-        Assert.Contains(expectedState, statesManager.CalledWithStates);
+        var expectedState = config.GetMonitoredState(smi.GetStateMachine());
+        Assert.Contains(expectedState, statesManager.WaitArgs);
+        Assert.Contains(expectedState, statesManager.ContinuationArgs);
     }
 
     [Test, TestCaseSource(nameof(ExitTestArgs))]
@@ -53,20 +55,26 @@ public class DisableChoreStateTransitionTest : AbstractChoreTest {
         StateTransitionConfig config
     ) {
         var statesManager = Runtime.Instance.Dependencies.Get<FakeStatesManager>();
-        statesManager.CalledWithStates.Clear();
+        statesManager.WaitArgs.Clear();
 
         var chore = CreateChore(choreType, choreArgsFunc.Invoke());
 
         var smi = statesManager.GetSmi(chore);
-        var expectedState = config.GetMonitoredState(smi.stateMachine);
-        Assert.Contains(expectedState, statesManager.CalledWithStates);
+        var expectedState = config.GetMonitoredState(smi.GetStateMachine());
+        Assert.Contains(expectedState, statesManager.WaitArgs);
     }
 
     private class FakeStatesManager : StatesManager {
-        public readonly List<StateMachine.BaseState> CalledWithStates = new();
+        public readonly List<StateMachine.BaseState> WaitArgs = new();
+        public readonly List<StateMachine.BaseState> ContinuationArgs = new();
 
         public override void ReplaceWithWaitState(StateMachine.BaseState stateToBeSynced) {
-            CalledWithStates.Add(stateToBeSynced);
+            WaitArgs.Add(stateToBeSynced);
+        }
+
+        public override StateMachine.BaseState AddContinuationState(StateMachine.BaseState stateToBeSynced) {
+            ContinuationArgs.Add(stateToBeSynced);
+            return null!;
         }
     }
 

--- a/src/MultiplayerMod.Test/Multiplayer/States/StatesManagerTest.cs
+++ b/src/MultiplayerMod.Test/Multiplayer/States/StatesManagerTest.cs
@@ -55,6 +55,30 @@ public class StatesManagerTest : AbstractChoreTest {
         Assert.AreEqual(expectedDictionary, waitHostState.ParametersArgs.Get(smi));
     }
 
+    [Test]
+    public void AddContinuationState_CopiesArgumentsFromOriginal() {
+        var statesManager = Runtime.Instance.Dependencies.Get<StatesManager>();
+        var stateToBeSynced =
+            new GameStateMachine<AggressiveChore.States, AggressiveChore.StatesInstance, AggressiveChore, object>.State {
+                defaultState = new StateMachine.BaseState(),
+                enterActions = new List<StateMachine.Action> { new() },
+                exitActions = new List<StateMachine.Action> { new() },
+                updateActions = new List<StateMachine.UpdateAction> { new() },
+                events = new List<StateEvent> {
+                    new GameStateMachine<AggressiveChore.States, AggressiveChore.StatesInstance, AggressiveChore, object>.GameEvent(GameHashes.Absorb, null, null, null)
+                },
+                sm = new AggressiveChore.States()
+            };
+
+        var createdState = statesManager.AddContinuationState(stateToBeSynced);
+
+        Assert.AreEqual(stateToBeSynced.defaultState, createdState.defaultState);
+        Assert.Null(createdState.enterActions);
+        Assert.AreEqual(stateToBeSynced.exitActions, createdState.exitActions);
+        Assert.Null(createdState.updateActions);
+        Assert.Null(createdState.events);
+    }
+
     [Test, TestCaseSource(nameof(EnterTestArgs))]
     public void EnterArgs_DisableChoreStateTransition(
         Type choreType,

--- a/src/MultiplayerMod/Game/Chores/Types/StateTransitionConfig.cs
+++ b/src/MultiplayerMod/Game/Chores/Types/StateTransitionConfig.cs
@@ -9,7 +9,6 @@ public record StateTransitionConfig(
     string[] ParameterName
 ) {
 
-    /// TODO: Execute command on the client
     public static StateTransitionConfig OnEnter(string stateName, params string[] parameterName) =>
         new(TransitionTypeEnum.Enter, stateName, null, parameterName);
 

--- a/src/MultiplayerMod/Multiplayer/Commands/Chores/States/TransitChoreToState.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Chores/States/TransitChoreToState.cs
@@ -14,11 +14,25 @@ public class TransitChoreToState : MultiplayerCommand {
     public readonly string? TargetState;
     public readonly Dictionary<int, object?> Args;
 
-    public TransitChoreToState(ChoreTransitStateArgs transitData) {
-        ChoreId = transitData.Chore.MultiplayerId();
-        TargetState = transitData.TargetState;
-        Args = transitData.Args.ToDictionary(a => a.Key, a => ArgumentUtils.WrapObject(a.Value));
+    private TransitChoreToState(MultiplayerId choreId, string? targetState, Dictionary<int, object?> args) {
+        ChoreId = choreId;
+        TargetState = targetState;
+        Args = args;
     }
+
+    public static TransitChoreToState EnterTransition(ChoreTransitStateArgs transitData) =>
+        new(
+            transitData.Chore.MultiplayerId(),
+            transitData.TargetState! + "_" + StatesManager.ContinuationName,
+            transitData.Args.ToDictionary(a => a.Key, a => ArgumentUtils.WrapObject(a.Value))
+        );
+
+    public static TransitChoreToState ExitTransition(ChoreTransitStateArgs transitData) =>
+        new(
+            transitData.Chore.MultiplayerId(),
+            transitData.TargetState,
+            transitData.Args.ToDictionary(a => a.Key, a => ArgumentUtils.WrapObject(a.Value))
+        );
 
     public override void Execute(MultiplayerCommandContext context) {
         var args = Args.ToDictionary(a => a.Key, a => ArgumentUtils.UnWrapObject(a.Value));

--- a/src/MultiplayerMod/Multiplayer/CoreOperations/Binders/HostEventsBinder.cs
+++ b/src/MultiplayerMod/Multiplayer/CoreOperations/Binders/HostEventsBinder.cs
@@ -46,8 +46,12 @@ public class HostEventsBinder {
             new CreateHostChore(args),
             MultiplayerCommandOptions.SkipHost
         );
+        ChoreStateEvents.OnStateEnter += args => server.Send(
+            TransitChoreToState.EnterTransition(args),
+            MultiplayerCommandOptions.SkipHost
+        );
         ChoreStateEvents.OnStateExit += args => server.Send(
-            new TransitChoreToState(args),
+            TransitChoreToState.ExitTransition(args),
             MultiplayerCommandOptions.SkipHost
         );
         ChoreStateEvents.OnStateUpdate += args => server.Send(

--- a/src/MultiplayerMod/Multiplayer/Patches/Chores/States/DisableChoreStateTransition.cs
+++ b/src/MultiplayerMod/Multiplayer/Patches/Chores/States/DisableChoreStateTransition.cs
@@ -30,11 +30,20 @@ public static class DisableChoreStateTransition {
     public static void InitializeStatesPatch(StateMachine __instance) {
         var config = ChoreList.Config[__instance.GetType().DeclaringType].StatesTransitionSync;
 
-        foreach (var stateTransitionConfig in config.StateTransitionConfigs.Where(
-                     it => it.TransitionType is TransitionTypeEnum.Exit or TransitionTypeEnum.Enter
-                 )) {
+        foreach (var stateTransitionConfig in config.StateTransitionConfigs) {
+            var statesManager = Runtime.Instance.Dependencies.Get<StatesManager>();
             var stateToBeSynced = stateTransitionConfig.GetMonitoredState(__instance);
-            Runtime.Instance.Dependencies.Get<StatesManager>().ReplaceWithWaitState(stateToBeSynced);
+            switch (stateTransitionConfig.TransitionType) {
+                case TransitionTypeEnum.Exit: {
+                    statesManager.ReplaceWithWaitState(stateToBeSynced);
+                    break;
+                }
+                case TransitionTypeEnum.Enter: {
+                    statesManager.ReplaceWithWaitState(stateToBeSynced);
+                    statesManager.AddContinuationState(stateToBeSynced);
+                    break;
+                }
+            }
         }
     }
 }

--- a/src/MultiplayerMod/Multiplayer/States/ContinuationState.cs
+++ b/src/MultiplayerMod/Multiplayer/States/ContinuationState.cs
@@ -1,0 +1,19 @@
+﻿namespace MultiplayerMod.Multiplayer.States;
+
+public class
+    ContinuationState<StateMachineType, StateMachineInstanceType, MasterType, DefType> : StateMachine<StateMachineType, StateMachineInstanceType, MasterType, DefType>.State
+    where StateMachineInstanceType : StateMachine.Instance
+    where MasterType : IStateMachineTarget {
+
+    public ContinuationState(StateMachine sm, StateMachine.BaseState original) {
+        name = StatesManager.ContinuationName;
+
+        // enter and update actions must be synced differently.
+        exitActions = original.exitActions;
+        defaultState = original.defaultState;
+
+        var stateMachineType = sm.GetType();
+        var root = stateMachineType.GetField("root").GetValue(sm);
+        stateMachineType.GetMethod("BindState")!.Invoke(sm, new[] { root, this, name });
+    }
+}

--- a/src/MultiplayerMod/Multiplayer/States/WaitHostState.cs
+++ b/src/MultiplayerMod/Multiplayer/States/WaitHostState.cs
@@ -14,7 +14,7 @@ public class
     [UsedImplicitly] public WaitStateParam<Dictionary<int, object?>> ParametersArgs { get; }
 
     public WaitHostState(StateMachine sm) {
-        name = StatesManager.StateName;
+        name = StatesManager.WaitStateName;
         TransitionAllowed = InitParam(sm, false);
         TargetState = InitParam(sm, (string?) null);
         ParametersArgs = InitParam(sm, new Dictionary<int, object?>());


### PR DESCRIPTION
In order to avoid cycle loops (enter -> wait -> command -> enter -> wait -> ....) introduced new state `ContinuationState` which is a copy of original enter state. Now the flow looks like: enter -> wait -> command -> continuation