### PR TITLE
#13 Specify Chore configs for chores using sensors.

### DIFF
--- a/src/MultiplayerMod.Test/Game/Chores/AbstractChoreTest.cs
+++ b/src/MultiplayerMod.Test/Game/Chores/AbstractChoreTest.cs
@@ -476,7 +476,15 @@ public class AbstractChoreTest : AbstractGameTest {
             },
             new object[] {
                 typeof(MoveToSafetyChore),
-                new Func<object[]>(() => new object[] { Minion })
+                new Func<object[]>(() => new object[] { Minion }),
+                new object[] {
+                    new object[] {
+                        ChoreList.Config[typeof(MoveToSafetyChore)].StatesTransitionSync.StateTransitionConfigs[0],
+                        new Func<Dictionary<int, object?>>(
+                            () => new Dictionary<int, object?>()
+                        )
+                    }
+                }
             },
             new object[] {
                 typeof(RecoverBreathChore),
@@ -531,7 +539,21 @@ public class AbstractChoreTest : AbstractGameTest {
             },
             new object[] {
                 typeof(BalloonArtistChore),
-                new Func<object[]>(() => new object[] { Minion })
+                new Func<object[]>(() => new object[] { Minion }),
+                new object[] {
+                    new object[] {
+                        ChoreList.Config[typeof(BalloonArtistChore)].StatesTransitionSync.StateTransitionConfigs[0],
+                        new Func<Dictionary<int, object?>>(
+                            () => new Dictionary<int, object?>()
+                        )
+                    },
+                    new object[] {
+                        ChoreList.Config[typeof(BalloonArtistChore)].StatesTransitionSync.StateTransitionConfigs[1],
+                        new Func<Dictionary<int, object?>>(
+                            () => new Dictionary<int, object?>()
+                        )
+                    }
+                }
             },
             new object[] {
                 typeof(BansheeChore),
@@ -564,11 +586,69 @@ public class AbstractChoreTest : AbstractGameTest {
             },
             new object[] {
                 typeof(IdleChore),
-                new Func<object[]>(() => new object[] { Minion })
+                new Func<object[]>(() => new object[] { Minion }),
+                new object[] {
+                    new object[] {
+                        ChoreList.Config[typeof(IdleChore)].StatesTransitionSync.StateTransitionConfigs[0],
+                        new Func<Dictionary<int, object?>>(
+                            () => new Dictionary<int, object?>()
+                        )
+                    },
+                    new object[] {
+                        ChoreList.Config[typeof(IdleChore)].StatesTransitionSync.StateTransitionConfigs[1],
+                        new Func<Dictionary<int, object?>>(
+                            () => new Dictionary<int, object?>()
+                        )
+                    },
+                    new object[] {
+                        ChoreList.Config[typeof(IdleChore)].StatesTransitionSync.StateTransitionConfigs[2],
+                        new Func<Dictionary<int, object?>>(
+                            () => new Dictionary<int, object?>()
+                        )
+                    },
+                    new object[] {
+                        ChoreList.Config[typeof(IdleChore)].StatesTransitionSync.StateTransitionConfigs[3],
+                        new Func<Dictionary<int, object?>>(
+                            () => new Dictionary<int, object?>()
+                        )
+                    }
+                }
             },
             new object[] {
                 typeof(MingleChore),
-                new Func<object[]>(() => new object[] { Minion })
+                new Func<object[]>(() => new object[] { Minion }),
+                new object[] {
+                    new object[] {
+                        ChoreList.Config[typeof(MingleChore)].StatesTransitionSync.StateTransitionConfigs[0],
+                        new Func<Dictionary<int, object?>>(
+                            () => new Dictionary<int, object?>()
+                        )
+                    },
+                    new object[] {
+                        ChoreList.Config[typeof(MingleChore)].StatesTransitionSync.StateTransitionConfigs[1],
+                        new Func<Dictionary<int, object?>>(
+                            () => new Dictionary<int, object?>()
+                        )
+                    },
+                    new object[] {
+                        ChoreList.Config[typeof(MingleChore)].StatesTransitionSync.StateTransitionConfigs[2],
+                        new Func<Dictionary<int, object?>>(
+                            () => new Dictionary<int, object?>()
+                        )
+                    },
+                    new object[] {
+                        ChoreList.Config[typeof(MingleChore)].StatesTransitionSync.StateTransitionConfigs[3],
+                        new Func<Dictionary<int, object?>>(
+                            () => new Dictionary<int, object?>()
+                        )
+                    },
+                    new object[] {
+                        ChoreList.Config[typeof(MingleChore)].StatesTransitionSync.StateTransitionConfigs[4],
+                        new Func<Dictionary<int, object?>>(
+                            () => new Dictionary<int, object?>()
+                        )
+                    },
+                }
             },
             new object[] {
                 typeof(VomitChore),

--- a/src/MultiplayerMod/Game/Chores/ChoreList.cs
+++ b/src/MultiplayerMod/Game/Chores/ChoreList.cs
@@ -128,8 +128,12 @@ public static class ChoreList {
                 )
             }, {
                 typeof(MoveToSafetyChore),
-                // TODO sync SafeCellSensor instead
-                ChoreSyncConfig.FullyDeterminedByInput()
+                ChoreSyncConfig.Dynamic(
+                    StatesTransitionConfig.Enabled<MoveToSafetyChore.States>(
+                        // TODO update cell as well
+                        StateTransitionConfig.OnMove(nameof(MoveToSafetyChore.States.move))
+                    )
+                )
             }, {
                 typeof(RecoverBreathChore),
                 ChoreSyncConfig.Dynamic(
@@ -243,8 +247,12 @@ public static class ChoreList {
                 )
             }, {
                 typeof(BalloonArtistChore),
-                // TODO sync balloonArtistCellSensor instead
-                ChoreSyncConfig.FullyDeterminedByInput()
+                ChoreSyncConfig.Dynamic(
+                    StatesTransitionConfig.Enabled<BalloonArtistChore.States>(
+                        StateTransitionConfig.OnTransition(nameof(BalloonArtistChore.States.goToStand)),
+                        StateTransitionConfig.OnMove(nameof(BalloonArtistChore.States.goToStand))
+                    )
+                )
             }, {
                 typeof(BansheeChore),
                 ChoreSyncConfig.Dynamic(
@@ -261,12 +269,34 @@ public static class ChoreList {
                 ChoreSyncConfig.FullyDeterminedByInput(GlobalChoreProviderStatusEnum.OnTodo)
             }, {
                 typeof(IdleChore),
-                // TODO sync idleCellSensor instead
-                ChoreSyncConfig.FullyDeterminedByInput()
+                ChoreSyncConfig.Dynamic(
+                    StatesTransitionConfig.Enabled<IdleChore.States>(
+                        // To prevent update callback on client
+                        StateTransitionConfig.OnUpdate(
+                            $"{nameof(IdleChore.States.idle)}.{nameof(IdleChore.States.idle.ontube)}"
+                        ),
+                        StateTransitionConfig.OnExit(
+                            $"{nameof(IdleChore.States.idle)}.{nameof(IdleChore.States.idle.ontube)}"
+                        ),
+                        StateTransitionConfig.OnTransition(
+                            $"{nameof(IdleChore.States.idle)}.{nameof(IdleChore.States.idle.move)}"
+                        ),
+                        StateTransitionConfig.OnMove(
+                            $"{nameof(IdleChore.States.idle)}.{nameof(IdleChore.States.idle.move)}"
+                        )
+                    )
+                )
             }, {
                 typeof(MingleChore),
-                // TODO sync mingleCellSensor instead
-                ChoreSyncConfig.FullyDeterminedByInput()
+                ChoreSyncConfig.Dynamic(
+                    StatesTransitionConfig.Enabled<MingleChore.States>(
+                        StateTransitionConfig.OnTransition(nameof(MingleChore.States.mingle)),
+                        StateTransitionConfig.OnTransition(nameof(MingleChore.States.move)),
+                        StateTransitionConfig.OnTransition(nameof(MingleChore.States.walk)),
+                        StateTransitionConfig.OnMove(nameof(MingleChore.States.move)),
+                        StateTransitionConfig.OnMove(nameof(MingleChore.States.walk))
+                    )
+                )
             }, {
                 typeof(VomitChore),
                 ChoreSyncConfig.Dynamic(

--- a/src/MultiplayerMod/Game/Chores/States/ChoreStateEvents.cs
+++ b/src/MultiplayerMod/Game/Chores/States/ChoreStateEvents.cs
@@ -48,8 +48,9 @@ public static class ChoreStateEvents {
     }
 
     private static void BindCallback(StateMachine sm, StateTransitionConfig config) {
-        if (config.TransitionType == TransitionTypeEnum.MoveTo) {
-            // TODO handle moveTo transition types.
+        if (config.TransitionType == TransitionTypeEnum.MoveTo ||
+            config.TransitionType == TransitionTypeEnum.Transition) {
+            // TODO handle moveTo and transition types.
             return;
         }
         var state = config.GetMonitoredState(sm);

--- a/src/MultiplayerMod/Game/Chores/Types/StateTransitionConfig.cs
+++ b/src/MultiplayerMod/Game/Chores/Types/StateTransitionConfig.cs
@@ -9,6 +9,13 @@ public record StateTransitionConfig(
     string[] ParameterName
 ) {
 
+    /// Host:
+    ///  - Sends command to all clients upon enter handler call.
+    /// Client:
+    ///  - Prevents transition to specified state.
+    ///  - Transits to WaitHostState instead.
+    ///  - Transits to specified Continuation state (artificial copy of original) upon host command.
+    ///  - Sets values specified by host upon command.
     public static StateTransitionConfig OnEnter(string stateName, params string[] parameterName) =>
         new(TransitionTypeEnum.Enter, stateName, null, parameterName);
 
@@ -21,6 +28,10 @@ public record StateTransitionConfig(
     ///  - Sets values specified by host upon command.
     public static StateTransitionConfig OnExit(string stateName, params string[] parameterName) =>
         new(TransitionTypeEnum.Exit, stateName, null, parameterName);
+
+    // TODO implement handling (discard enter and update handlers, subscribe to onExit and act as OnExit)
+    public static StateTransitionConfig OnTransition(string stateName) =>
+        new(TransitionTypeEnum.Transition, stateName, null, Array.Empty<string>());
 
     /// TODO: Adjust client logic (prevent / postpone execution of original handler)
     /// TODO: Execute command on the client

--- a/src/MultiplayerMod/Game/Chores/Types/TransitionTypeEnum.cs
+++ b/src/MultiplayerMod/Game/Chores/Types/TransitionTypeEnum.cs
@@ -6,5 +6,6 @@ public enum TransitionTypeEnum {
     Exit,
     MoveTo,
     Update,
-    EventHandler
+    EventHandler,
+    Transition
 }


### PR DESCRIPTION
Syncing sensors themself won't guarantee state machine consistencies. So sync transitions results from cell sensor (Exit, Move).

Introduced new `transition` transition type. Basically it is similar to OnExit but will prevent undesired chore transition upon default conditions.