### PR TITLE
#13 Split TransitChoreToState event to 2: AllowStateTransition and TransitToState.cs

### DIFF
--- a/src/MultiplayerMod.Test/Game/Chores/States/ChoreStateEventsTest.cs
+++ b/src/MultiplayerMod.Test/Game/Chores/States/ChoreStateEventsTest.cs
@@ -205,18 +205,15 @@ public class ChoreStateEventsTest : AbstractChoreTest {
         smi.stateMachine.GetState("root").transitions?.Clear();
         state.enterActions?.Clear();
         state.updateActions?.Clear();
-        ChoreTransitStateArgs? firedArgs = null;
-        ChoreStateEvents.OnStateExit += args => firedArgs = args;
+        MoveToArgs? firedArgs = null;
+        ChoreStateEvents.OnExitMoveTo += args => firedArgs = args;
         smi.GoTo(state);
 
         smi.GoTo("root");
 
-        var expectedDictionary = expectedDictionaryFunc.Invoke();
         Assert.NotNull(firedArgs);
         Assert.AreEqual(chore, firedArgs!.Chore);
         Assert.AreEqual("root", firedArgs!.TargetState);
-        Assert.AreEqual(expectedDictionary.Keys, firedArgs!.Args.Keys);
-        Assert.AreEqual(expectedDictionary.Values, firedArgs.Args.Values);
     }
 
     [Test, TestCaseSource(nameof(MoveToTestArgs))]
@@ -240,7 +237,7 @@ public class ChoreStateEventsTest : AbstractChoreTest {
         state.transitions.Clear();
         smi.stateMachine.GetState("root").transitions?.Clear();
         MoveToArgs? firedArgs = null;
-        ChoreStateEvents.OnStartMoveTo += args => firedArgs = args;
+        ChoreStateEvents.OnEnterMoveTo += args => firedArgs = args;
 
         smi.GoTo(state);
 

--- a/src/MultiplayerMod.Test/Multiplayer/Commands/Chores/States/AllowStateTransitionTest.cs
+++ b/src/MultiplayerMod.Test/Multiplayer/Commands/Chores/States/AllowStateTransitionTest.cs
@@ -18,7 +18,7 @@ using NUnit.Framework;
 namespace MultiplayerMod.Test.Multiplayer.Commands.Chores.States;
 
 [TestFixture]
-public class TransitChoreToStateTest : AbstractChoreTest {
+public class AllowStateTransitionTest : AbstractChoreTest {
 
     [OneTimeSetUp]
     public static void OneTimeSetUp() {
@@ -46,7 +46,7 @@ public class TransitChoreToStateTest : AbstractChoreTest {
             config.StateToMonitorName,
             stateTransitionArgsFunc.Invoke()
         );
-        var command = TransitChoreToState.EnterTransition(arg);
+        var command = AllowStateTransition.EnterTransition(arg);
 
         command.Execute(new MultiplayerCommandContext(null, new MultiplayerCommandRuntimeAccessor(Runtime.Instance)));
 
@@ -70,7 +70,7 @@ public class TransitChoreToStateTest : AbstractChoreTest {
             config.StateToMonitorName,
             stateTransitionArgsFunc.Invoke()
         );
-        var command = TransitChoreToState.ExitTransition(arg);
+        var command = AllowStateTransition.ExitTransition(arg);
 
         command.Execute(new MultiplayerCommandContext(null, new MultiplayerCommandRuntimeAccessor(Runtime.Instance)));
 
@@ -94,7 +94,7 @@ public class TransitChoreToStateTest : AbstractChoreTest {
             config.StateToMonitorName,
             stateTransitionArgsFunc.Invoke()
         );
-        var command = TransitChoreToState.ExitTransition(arg);
+        var command = AllowStateTransition.ExitTransition(arg);
 
         command.Execute(new MultiplayerCommandContext(null, new MultiplayerCommandRuntimeAccessor(Runtime.Instance)));
 
@@ -118,7 +118,7 @@ public class TransitChoreToStateTest : AbstractChoreTest {
             config.StateToMonitorName,
             stateTransitionArgsFunc.Invoke()
         );
-        var command = TransitChoreToState.EnterTransition(arg);
+        var command = AllowStateTransition.EnterTransition(arg);
         var messageFactory = new NetworkMessageFactory();
         var messageProcessor = new NetworkMessageProcessor();
         NetworkMessage? networkMessage = null;
@@ -128,9 +128,9 @@ public class TransitChoreToStateTest : AbstractChoreTest {
         }
 
         Assert.AreEqual(command.GetType(), networkMessage?.Command.GetType());
-        Assert.AreEqual(command.ChoreId, ((TransitChoreToState) networkMessage!.Command).ChoreId);
-        Assert.AreEqual(command.TargetState, ((TransitChoreToState) networkMessage.Command).TargetState);
-        Assert.AreEqual(command.Args.Keys, ((TransitChoreToState) networkMessage.Command).Args.Keys);
+        Assert.AreEqual(command.ChoreId, ((AllowStateTransition) networkMessage!.Command).ChoreId);
+        Assert.AreEqual(command.TargetState, ((AllowStateTransition) networkMessage.Command).TargetState);
+        Assert.AreEqual(command.Args.Keys, ((AllowStateTransition) networkMessage.Command).Args.Keys);
     }
 
     [Test, TestCaseSource(nameof(ExitTestArgs))]
@@ -147,7 +147,7 @@ public class TransitChoreToStateTest : AbstractChoreTest {
             config.StateToMonitorName,
             stateTransitionArgsFunc.Invoke()
         );
-        var command = TransitChoreToState.ExitTransition(arg);
+        var command = AllowStateTransition.ExitTransition(arg);
         var messageFactory = new NetworkMessageFactory();
         var messageProcessor = new NetworkMessageProcessor();
         NetworkMessage? networkMessage = null;
@@ -157,9 +157,9 @@ public class TransitChoreToStateTest : AbstractChoreTest {
         }
 
         Assert.AreEqual(command.GetType(), networkMessage?.Command.GetType());
-        Assert.AreEqual(command.ChoreId, ((TransitChoreToState) networkMessage!.Command).ChoreId);
-        Assert.AreEqual(command.TargetState, ((TransitChoreToState) networkMessage.Command).TargetState);
-        Assert.AreEqual(command.Args.Keys, ((TransitChoreToState) networkMessage.Command).Args.Keys);
+        Assert.AreEqual(command.ChoreId, ((AllowStateTransition) networkMessage!.Command).ChoreId);
+        Assert.AreEqual(command.TargetState, ((AllowStateTransition) networkMessage.Command).TargetState);
+        Assert.AreEqual(command.Args.Keys, ((AllowStateTransition) networkMessage.Command).Args.Keys);
     }
 
     [Test, TestCaseSource(nameof(TransitionTestArgs))]
@@ -176,7 +176,7 @@ public class TransitChoreToStateTest : AbstractChoreTest {
             config.StateToMonitorName,
             stateTransitionArgsFunc.Invoke()
         );
-        var command = TransitChoreToState.ExitTransition(arg);
+        var command = AllowStateTransition.ExitTransition(arg);
         var messageFactory = new NetworkMessageFactory();
         var messageProcessor = new NetworkMessageProcessor();
         NetworkMessage? networkMessage = null;
@@ -186,9 +186,9 @@ public class TransitChoreToStateTest : AbstractChoreTest {
         }
 
         Assert.AreEqual(command.GetType(), networkMessage?.Command.GetType());
-        Assert.AreEqual(command.ChoreId, ((TransitChoreToState) networkMessage!.Command).ChoreId);
-        Assert.AreEqual(command.TargetState, ((TransitChoreToState) networkMessage.Command).TargetState);
-        Assert.AreEqual(command.Args.Keys, ((TransitChoreToState) networkMessage.Command).Args.Keys);
+        Assert.AreEqual(command.ChoreId, ((AllowStateTransition) networkMessage!.Command).ChoreId);
+        Assert.AreEqual(command.TargetState, ((AllowStateTransition) networkMessage.Command).TargetState);
+        Assert.AreEqual(command.Args.Keys, ((AllowStateTransition) networkMessage.Command).Args.Keys);
     }
 
     private class FakeStatesManager : StatesManager {

--- a/src/MultiplayerMod.Test/Multiplayer/Commands/Chores/States/TransitToStateTest.cs
+++ b/src/MultiplayerMod.Test/Multiplayer/Commands/Chores/States/TransitToStateTest.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using MultiplayerMod.Core.Dependency;
+using MultiplayerMod.Core.Events;
+using MultiplayerMod.Game.Chores.Types;
+using MultiplayerMod.ModRuntime;
+using MultiplayerMod.Multiplayer.Commands;
+using MultiplayerMod.Multiplayer.Commands.Chores.States;
+using MultiplayerMod.Multiplayer.Objects;
+using MultiplayerMod.Multiplayer.States;
+using MultiplayerMod.Network;
+using MultiplayerMod.Platform.Steam.Network.Messaging;
+using MultiplayerMod.Test.Game.Chores;
+using NUnit.Framework;
+
+namespace MultiplayerMod.Test.Multiplayer.Commands.Chores.States;
+
+[TestFixture]
+public class TransitToStateTest : AbstractChoreTest {
+
+    [OneTimeSetUp]
+    public static void OneTimeSetUp() {
+        var di = (DependencyContainer) Runtime.Instance.Dependencies;
+        di.Register(new DependencyInfo(nameof(EventDispatcher), typeof(EventDispatcher), false));
+        di.Register(new DependencyInfo(nameof(StatesManager), typeof(StatesManager), false));
+    }
+
+    [SetUp]
+    public void SetUp() {
+        CreateTestData();
+    }
+
+    [Test, TestCaseSource(nameof(MoveToTestArgs))]
+    public void ExecutionTest(
+        Type choreType,
+        Func<object[]> createChoreArgsFunc,
+        Func<Dictionary<int, object?>> stateTransitionArgsFunc,
+        StateTransitionConfig config
+    ) {
+        var chore = CreateChore(choreType, createChoreArgsFunc.Invoke());
+        chore.Register(new MultiplayerId(Guid.NewGuid()));
+        var smi = (StateMachine.Instance) chore.GetType().GetProperty("smi").GetValue(chore);
+        smi.stateMachine.GetState("root").transitions?.Clear();
+        var stateName = config.StateToMonitorName != "root" ? "root" : "random";
+        var command = new TransitToState(chore, stateName);
+
+        command.Execute(new MultiplayerCommandContext(null, new MultiplayerCommandRuntimeAccessor(Runtime.Instance)));
+
+        Assert.AreEqual(smi.stateMachine.GetState(stateName), smi.GetCurrentState());
+    }
+
+    [Test, TestCaseSource(nameof(MoveToTestArgs))]
+    public void SerializationTest(
+        Type choreType,
+        Func<object[]> createChoreArgsFunc,
+        Func<Dictionary<int, object?>> stateTransitionArgsFunc,
+        StateTransitionConfig config
+    ) {
+        var chore = CreateChore(choreType, createChoreArgsFunc.Invoke());
+        chore.Register(new MultiplayerId(Guid.NewGuid()));
+        var command = new TransitToState(chore, config.StateToMonitorName != "root" ? "root" : "random");
+        var messageFactory = new NetworkMessageFactory();
+        var messageProcessor = new NetworkMessageProcessor();
+        NetworkMessage? networkMessage = null;
+
+        foreach (var messageHandle in messageFactory.Create(command, MultiplayerCommandOptions.SkipHost).ToArray()) {
+            networkMessage = messageProcessor.Process(1u, messageHandle);
+        }
+
+        Assert.AreEqual(command.GetType(), networkMessage?.Command.GetType());
+        Assert.AreEqual(command.ChoreId, ((TransitToState) networkMessage!.Command).ChoreId);
+        Assert.AreEqual(command.State, ((TransitToState) networkMessage.Command).State);
+    }
+
+}

--- a/src/MultiplayerMod/Multiplayer/Commands/Chores/States/AllowStateTransition.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Chores/States/AllowStateTransition.cs
@@ -8,26 +8,26 @@ using MultiplayerMod.Multiplayer.States;
 namespace MultiplayerMod.Multiplayer.Commands.Chores.States;
 
 [Serializable]
-public class TransitChoreToState : MultiplayerCommand {
+public class AllowStateTransition : MultiplayerCommand {
 
     public readonly MultiplayerId ChoreId;
     public readonly string? TargetState;
     public readonly Dictionary<int, object?> Args;
 
-    private TransitChoreToState(MultiplayerId choreId, string? targetState, Dictionary<int, object?> args) {
+    private AllowStateTransition(MultiplayerId choreId, string? targetState, Dictionary<int, object?> args) {
         ChoreId = choreId;
         TargetState = targetState;
         Args = args;
     }
 
-    public static TransitChoreToState EnterTransition(ChoreTransitStateArgs transitData) =>
+    public static AllowStateTransition EnterTransition(ChoreTransitStateArgs transitData) =>
         new(
             transitData.Chore.MultiplayerId(),
             transitData.TargetState! + "_" + StatesManager.ContinuationName,
             transitData.Args.ToDictionary(a => a.Key, a => ArgumentUtils.WrapObject(a.Value))
         );
 
-    public static TransitChoreToState ExitTransition(ChoreTransitStateArgs transitData) =>
+    public static AllowStateTransition ExitTransition(ChoreTransitStateArgs transitData) =>
         new(
             transitData.Chore.MultiplayerId(),
             transitData.TargetState,

--- a/src/MultiplayerMod/Multiplayer/Commands/Chores/States/TransitToState.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Chores/States/TransitToState.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using MultiplayerMod.Multiplayer.Objects;
+using MultiplayerMod.Multiplayer.States;
+
+namespace MultiplayerMod.Multiplayer.Commands.Chores.States;
+
+[Serializable]
+public class TransitToState : MultiplayerCommand {
+    public readonly MultiplayerId ChoreId;
+    public readonly string? State;
+
+    public TransitToState(Chore chore, string? state) {
+        ChoreId = chore.MultiplayerId();
+        State = state;
+    }
+
+    public override void Execute(MultiplayerCommandContext context) {
+        var chore = ChoreObjects.GetChore(ChoreId);
+        var smi = context.Runtime.Dependencies.Get<StatesManager>().GetSmi(chore);
+        smi.GoTo(State);
+    }
+}

--- a/src/MultiplayerMod/Multiplayer/CoreOperations/Binders/HostEventsBinder.cs
+++ b/src/MultiplayerMod/Multiplayer/CoreOperations/Binders/HostEventsBinder.cs
@@ -47,19 +47,23 @@ public class HostEventsBinder {
             MultiplayerCommandOptions.SkipHost
         );
         ChoreStateEvents.OnStateEnter += args => server.Send(
-            TransitChoreToState.EnterTransition(args),
+            AllowStateTransition.EnterTransition(args),
             MultiplayerCommandOptions.SkipHost
         );
-        ChoreStateEvents.OnStartMoveTo += args => server.Send(
+        ChoreStateEvents.OnEnterMoveTo += args => server.Send(
             new StartMove(args),
             MultiplayerCommandOptions.SkipHost
         );
         ChoreStateEvents.OnStateExit += args => server.Send(
-            TransitChoreToState.ExitTransition(args),
+            AllowStateTransition.ExitTransition(args),
+            MultiplayerCommandOptions.SkipHost
+        );
+        ChoreStateEvents.OnExitMoveTo += args => server.Send(
+            new TransitToState(args.Chore, args.TargetState),
             MultiplayerCommandOptions.SkipHost
         );
         ChoreStateEvents.OnStateTransition += args => server.Send(
-            TransitChoreToState.ExitTransition(args),
+            new TransitToState(args.Chore, args.TargetState),
             MultiplayerCommandOptions.SkipHost
         );
         ChoreStateEvents.OnStateUpdate += args => server.Send(


### PR DESCRIPTION
Old TransitChoreToState was based on assumption that stateMachine has WaitHostState, however it is not the case for move syncs and transition syncs. For those there is no waitHostState and therefore no waiting.