### PR TITLE
#13 Fix npe during state syncs.

### DIFF
--- a/src/MultiplayerMod.Test/Directory.Build.targets
+++ b/src/MultiplayerMod.Test/Directory.Build.targets
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
+    <Target Name="AfterBuild">
+        <Copy SourceFiles="$(ManagedPath)\Assembly-CSharp.dll" DestinationFolder="$(OutputPath)"/>
+        <Copy SourceFiles="$(ManagedPath)\Assembly-CSharp-firstpass.dll" DestinationFolder="$(OutputPath)"/>
+    </Target>
 </Project>

--- a/src/MultiplayerMod.Test/Multiplayer/Commands/Chores/States/StartMoveTest.cs
+++ b/src/MultiplayerMod.Test/Multiplayer/Commands/Chores/States/StartMoveTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MultiplayerMod.Core.Dependency;
 using MultiplayerMod.Core.Events;
+using MultiplayerMod.Core.Reflection;
 using MultiplayerMod.Game.Chores.States;
 using MultiplayerMod.Game.Chores.Types;
 using MultiplayerMod.ModRuntime;
@@ -54,7 +55,7 @@ public class StartMoveTest : AbstractChoreTest {
 
         command.Execute(new MultiplayerCommandContext(null, new MultiplayerCommandRuntimeAccessor(Runtime.Instance)));
 
-        var target = sm.GetType().GetField("stateTarget")!.GetValue(sm);
+        var target = sm.GetFieldValue("stateTarget");
         var navigator = (Navigator) target.GetType().GetMethod("Get")
             .MakeGenericMethod(typeof(Navigator))
             .Invoke(target, new object[] { smi });

--- a/src/MultiplayerMod.Test/Multiplayer/Commands/Chores/States/UpdateMoveTest.cs
+++ b/src/MultiplayerMod.Test/Multiplayer/Commands/Chores/States/UpdateMoveTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MultiplayerMod.Core.Dependency;
 using MultiplayerMod.Core.Events;
+using MultiplayerMod.Core.Reflection;
 using MultiplayerMod.Game.Chores.States;
 using MultiplayerMod.Game.Chores.Types;
 using MultiplayerMod.ModRuntime;
@@ -49,7 +50,7 @@ public class UpdateMoveTest : AbstractChoreTest {
         command.Execute(new MultiplayerCommandContext(null, new MultiplayerCommandRuntimeAccessor(Runtime.Instance)));
 
         var sm = smi.stateMachine;
-        var target = sm.GetType().GetField("stateTarget")!.GetValue(sm);
+        var target = sm.GetFieldValue("stateTarget");
         var navigator = (Navigator) target.GetType().GetMethod("Get")
             .MakeGenericMethod(typeof(Navigator))
             .Invoke(target, new object[] { smi });

--- a/src/MultiplayerMod.Test/Multiplayer/Patches/Chores/States/AdjustStateMachineTransitionsTest.cs
+++ b/src/MultiplayerMod.Test/Multiplayer/Patches/Chores/States/AdjustStateMachineTransitionsTest.cs
@@ -223,12 +223,12 @@ public class DisableChoreStateTransitionTest : AbstractChoreTest {
         public readonly List<StateMachine.BaseState> WaitArgs = new();
         public readonly List<StateMachine.BaseState> ContinuationArgs = new();
 
-        public override void AddAndTransitToWaiStateUponEnter(StateMachine.BaseState stateToBeSynced) {
-            WaitArgs.Add(stateToBeSynced);
+        public override void AddAndTransitToWaiStateUponEnter(StateMachine.BaseState state) {
+            WaitArgs.Add(state);
         }
 
-        public override StateMachine.BaseState AddContinuationState(StateMachine.BaseState stateToBeSynced) {
-            ContinuationArgs.Add(stateToBeSynced);
+        public override StateMachine.BaseState AddContinuationState(StateMachine.BaseState state) {
+            ContinuationArgs.Add(state);
             return null!;
         }
     }

--- a/src/MultiplayerMod.Test/MultiplayerMod.Test.csproj
+++ b/src/MultiplayerMod.Test/MultiplayerMod.Test.csproj
@@ -17,7 +17,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
         <PackageReference Include="NUnit" Version="3.13.3"/>
-        <PackageReference Include="AssemblyExposer.MSBuild.Task" Version="0.1.5" Private="true" />
+        <PackageReference Include="AssemblyExposer.MSBuild.Task" Version="0.1.5" Private="true"/>
     </ItemGroup>
     <ItemGroup>
         <Reference Include="Assembly-CSharp" HintPath="$(ExposedLibrariesPath)\Assembly-CSharp.dll"/>

--- a/src/MultiplayerMod/Core/Reflection/ReflectionExtension.cs
+++ b/src/MultiplayerMod/Core/Reflection/ReflectionExtension.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Reflection;
+
+namespace MultiplayerMod.Core.Reflection;
+
+public static class ReflectionExtension {
+
+    public static object GetFieldValue(this object obj, string fieldName) {
+        return GetFieldValue<object>(obj, fieldName);
+    }
+
+    public static T GetFieldValue<T>(this object obj, string fieldName) {
+        var type = obj.GetType();
+        while (type != typeof(object)) {
+            var field = type.GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            if (field != null) {
+                return (T) field.GetValue(obj);
+            }
+            type = type.BaseType;
+        }
+        throw new Exception($"Field {fieldName} not found in {obj.GetType()}");
+    }
+}

--- a/src/MultiplayerMod/Multiplayer/Commands/Chores/States/StartMove.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Chores/States/StartMove.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using MultiplayerMod.Core.Reflection;
 using MultiplayerMod.Game.Chores.States;
 using MultiplayerMod.Multiplayer.Objects;
 using MultiplayerMod.Multiplayer.States;
@@ -26,7 +27,7 @@ public class StartMove : MultiplayerCommand {
         smi.GoTo("root." + TargetState);
 
         var sm = smi.stateMachine;
-        var target = sm.GetType().GetField("stateTarget")!.GetValue(sm);
+        var target = sm.GetFieldValue("stateTarget");
         var navigator = (Navigator) target.GetType().GetMethod("Get")
             .MakeGenericMethod(typeof(Navigator))
             .Invoke(target, new object[] { smi });

--- a/src/MultiplayerMod/Multiplayer/Commands/Chores/States/UpdateMove.cs
+++ b/src/MultiplayerMod/Multiplayer/Commands/Chores/States/UpdateMove.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using MultiplayerMod.Core.Reflection;
 using MultiplayerMod.Game.Chores.States;
 using MultiplayerMod.Multiplayer.Objects;
 using MultiplayerMod.Multiplayer.States;
@@ -20,7 +21,7 @@ public class UpdateMove : MultiplayerCommand {
         var smi = context.Runtime.Dependencies.Get<StatesManager>().GetSmi(chore);
 
         var sm = smi.stateMachine;
-        var target = sm.GetType().GetField("stateTarget")!.GetValue(sm);
+        var target = sm.GetFieldValue("stateTarget");
         var navigator = (Navigator) target.GetType().GetMethod("Get")
             .MakeGenericMethod(typeof(Navigator))
             .Invoke(target, new object[] { smi });

--- a/src/MultiplayerMod/Multiplayer/Objects/StateMachineReferenceExtensions.cs
+++ b/src/MultiplayerMod/Multiplayer/Objects/StateMachineReferenceExtensions.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+using MultiplayerMod.Core.Reflection;
 using MultiplayerMod.Multiplayer.Objects.Reference;
 
 namespace MultiplayerMod.Multiplayer.Objects;
@@ -13,7 +13,5 @@ public static class StateMachineReferenceExtensions {
     // `controller` field is defined in StateMachine<,,,>.GenericInstance. However cast is impossible due to unknown
     // generic argument types. So reflection is the most handy way to get its value :(
     private static StateMachineController GetStateMachineController(StateMachine.Instance instance) =>
-        (StateMachineController) instance.GetType()
-            .GetField("controller", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .GetValue(instance);
+        instance.GetFieldValue<StateMachineController>("controller");
 }


### PR DESCRIPTION
Problem was undiscovered due to faulty tests which we successfully passing. Which has been resulted due to using exposed libraries while in game runtime libraries are not exposed.

Fixed by copying original libraries to test output directory. As result 69 tests has failed.

Applied fixes for those tests.