### PR TITLE
#1 Enable state patches for other execution levels.

### DIFF
--- a/src/MultiplayerMod/Game/Chores/States/ChoreStateEvents.cs
+++ b/src/MultiplayerMod/Game/Chores/States/ChoreStateEvents.cs
@@ -41,7 +41,7 @@ public static class ChoreStateEvents {
 
     [UsedImplicitly]
     [HarmonyPostfix]
-    [RequireExecutionLevel(ExecutionLevel.Game)]
+    [RequireExecutionLevel(ExecutionLevel.Multiplayer)]
     [RequireMultiplayerMode(MultiplayerMode.Host)]
     public static void Postfix(StateMachine __instance) {
         var choreType = __instance.GetType().DeclaringType;

--- a/src/MultiplayerMod/Multiplayer/Patches/Chores/States/AdjustStateMachineTransitions.cs
+++ b/src/MultiplayerMod/Multiplayer/Patches/Chores/States/AdjustStateMachineTransitions.cs
@@ -25,7 +25,7 @@ public static class AdjustStateMachineTransitions {
     [UsedImplicitly]
     [HarmonyPostfix]
     [RequireMultiplayerMode(MultiplayerMode.Client)]
-    [RequireExecutionLevel(ExecutionLevel.Game)]
+    [RequireExecutionLevel(ExecutionLevel.Multiplayer)]
     public static void InitializeStatesPatch(StateMachine __instance) {
         var config = ChoreList.Config[__instance.GetType().DeclaringType].StatesTransitionSync;
 


### PR DESCRIPTION
Otherwise a lot of patches were skipped (the one that was happening during world load). However as an outcome - new problem being surfaced: Existing chores does not have MultiplayerId after world load.