### PR TITLE
Fix Unity scheduler

### DIFF
--- a/src/MultiplayerMod.Test/Multiplayer/Patches/Chores/DisableClientChoreCreationPatchTest.cs
+++ b/src/MultiplayerMod.Test/Multiplayer/Patches/Chores/DisableClientChoreCreationPatchTest.cs
@@ -28,6 +28,7 @@ public class DisableClientChoreCreationPatchTest : AbstractChoreTest {
     [Test, TestCaseSource(nameof(GetCreationTestArgs))]
     public void ClientChoresMustBeCancelled(Type choreType, Func<object[]> choreArgsFunc) {
         var chore = CreateChore(choreType, choreArgsFunc.Invoke());
+        chore.addToDailyReport = false;
         var provider = chore.provider;
         Runtime.Instance.Dependencies.Get<UnityTaskScheduler>().Tick();
 

--- a/src/MultiplayerMod/Core/Scheduling/UntiyTaskScheduler.cs
+++ b/src/MultiplayerMod/Core/Scheduling/UntiyTaskScheduler.cs
@@ -27,8 +27,11 @@ public class UnityTaskScheduler : TaskScheduler {
             TryExecuteTask(snapshot[i]);
     }
 
-    public void Run(System.Action action) => tasks.Enqueue(
-        Task.Factory.StartNew(action, CancellationToken.None, TaskCreationOptions.None, this)
+    public void Run(System.Action action) => Task.Factory.StartNew(
+        action,
+        CancellationToken.None,
+        TaskCreationOptions.None,
+        this
     );
 
     private int CreateSnapshot() {

--- a/src/MultiplayerMod/Core/Scheduling/UntiyTaskScheduler.cs
+++ b/src/MultiplayerMod/Core/Scheduling/UntiyTaskScheduler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,8 +24,14 @@ public class UnityTaskScheduler : TaskScheduler {
 
     public void Tick() {
         var length = CreateSnapshot();
-        for (var i = 0; i < length; ++i)
-            TryExecuteTask(snapshot[i]);
+        for (var i = 0; i < length; ++i) {
+            var task = snapshot[i];
+            TryExecuteTask(task);
+            if (task.Status == TaskStatus.RanToCompletion)
+                continue;
+            if (task.Exception != null)
+                throw new Exception("Scheduled task threw an exception", task.Exception);
+        }
     }
 
     public void Run(System.Action action) => Task.Factory.StartNew(


### PR DESCRIPTION
I've noticed we have several issues with the Unity task scheduler:
- Duplicated tasks (double execution was prevented by the Task implementation anyway, but still)
- Exceptions aren't forwarded to the calling method (can produce false positive outcomes)

These issues are addressed in this PR.

@zuev93 Please check ``ClientChoresMustBeCancelled(WorkChore`1[MedicinalPillWorkable],System.Func`1[System.Object[]])``